### PR TITLE
Add token-based history trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ pip install -r requirements.txt
 export OPENROUTER_API_KEY="your-key-here"
 python recursive-thinking-ai.py
 ```
+You can also limit the context window by passing `max_context_tokens` when
+creating `EnhancedRecursiveThinkingChat`.
 
 ### The Secret Sauce
 The magic is in:


### PR DESCRIPTION
## Summary
- use a token-based heuristic to manage history size
- expose `max_context_tokens` configuration option
- document the new parameter in the README

## Testing
- `flake8 recursive_thinking_ai.py | head -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845046e4e648333bb8726719f4d82a3