### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ openai
 tiktoken
 structlog
 aiohttp
+
+opentelemetry-sdk
+opentelemetry-exporter-prometheus
+aiofiles


### PR DESCRIPTION
## Summary
- add opentelemetry packages and aiofiles to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68487899fc7c8333bf5681105bb6e639