### PR TITLE
Add API v2 integration tests

### DIFF
--- a/tests/test_recthink_web_v2.py
+++ b/tests/test_recthink_web_v2.py
@@ -1,0 +1,74 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import json  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+import recthink_web_v2  # noqa: E402
+from core.chat_v2 import ThinkingResult, ThinkingRound  # noqa: E402
+
+
+class DummyEngine:
+    async def think_and_respond(self, message, thinking_rounds=None, alternatives_per_round=3):
+        return ThinkingResult(
+            response="ok",
+            thinking_rounds=1,
+            thinking_history=[
+                ThinkingRound(
+                    round_number=0,
+                    response="ok",
+                    alternatives=[],
+                    selected=True,
+                    explanation="init",
+                    quality_score=0.5,
+                    duration=0.0,
+                )
+            ],
+            total_tokens=1,
+            processing_time=0.1,
+            convergence_reason="done",
+            metadata={},
+        )
+
+    async def think_stream(self, message, context=None):
+        yield {"stage": "start", "response": "partial", "quality": 0.1}
+        yield {"stage": "end", "response": "final", "quality": 0.2}
+
+
+def setup_module(module):
+    recthink_web_v2.chat_sessions.clear()
+
+
+def test_chat_endpoint(monkeypatch):
+    client = TestClient(recthink_web_v2.app)
+    monkeypatch.setattr(recthink_web_v2, "create_default_engine", lambda config: DummyEngine())
+
+    resp = client.post("/chat", json={"session_id": "s1", "message": "hi"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["session_id"] == "s1"
+    assert data["response"] == "ok"
+    assert data["thinking_rounds"] == 1
+
+
+def test_websocket_endpoint(monkeypatch):
+    client = TestClient(recthink_web_v2.app)
+    monkeypatch.setattr(recthink_web_v2, "create_default_engine", lambda config: DummyEngine())
+
+    with client.websocket_connect("/ws/s2") as ws:
+        ws.send_text(json.dumps({"message": "hello"}))
+        data = ws.receive_json()
+        assert data["type"] == "final"
+        assert data["response"] == "ok"
+
+
+def test_websocket_stream(monkeypatch):
+    client = TestClient(recthink_web_v2.app)
+    monkeypatch.setattr(recthink_web_v2, "create_default_engine", lambda config: DummyEngine())
+
+    with client.websocket_connect("/ws/stream/s3") as ws:
+        ws.send_text(json.dumps({"message": "hi"}))
+        first = ws.receive_json()
+        second = ws.receive_json()
+        assert first["stage"] == "start"
+        assert second["stage"] == "end"

--- a/tests/test_recursive_engine_edges.py
+++ b/tests/test_recursive_engine_edges.py
@@ -1,0 +1,74 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest  # noqa: E402
+from core.chat_v2 import RecursiveThinkingEngine  # noqa: E402
+from core.context_manager import ContextManager  # noqa: E402
+from core.providers.cache import InMemoryLRUCache  # noqa: E402
+from core.interfaces import LLMProvider, QualityEvaluator  # noqa: E402
+
+
+class DummyLLM(LLMProvider):
+    def __init__(self, responses):
+        self.responses = responses
+        self.call = 0
+
+    async def chat(self, messages, *, temperature=0.7, **kwargs):
+        content = self.responses[self.call]
+        self.call += 1
+        return type(
+            "Resp",
+            (),
+            {
+                "content": content,
+                "usage": {"total_tokens": 1},
+                "model": "dummy",
+                "cached": False,
+            },
+        )()
+
+
+class DummyEvaluator(QualityEvaluator):
+    def score(self, response: str, prompt: str) -> float:
+        return 0.5
+
+
+class NoOpStrategy:
+    async def determine_rounds(self, prompt: str) -> int:
+        return 1
+
+    async def should_continue(self, rounds_completed, quality_scores, responses):
+        return rounds_completed < 1, "done"
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_alternative():
+    llm = DummyLLM(["initial", "not json"])
+    engine = RecursiveThinkingEngine(
+        llm=llm,
+        cache=InMemoryLRUCache(max_size=2),
+        evaluator=DummyEvaluator(),
+        context_manager=ContextManager(100, type("T", (), {"encode": lambda self, t: t.split()})()),
+        thinking_strategy=NoOpStrategy(),
+    )
+
+    result = await engine.think_and_respond("prompt", alternatives_per_round=1)
+    assert result.response == "not json"
+    assert result.thinking_history[1].explanation.startswith("JSON parsing failed")
+
+
+@pytest.mark.asyncio
+async def test_selection_out_of_range():
+    invalid = '{"alternatives": ["a"], "selection": "2", "reasoning": "pick second"}'
+    llm = DummyLLM(["initial", invalid])
+    engine = RecursiveThinkingEngine(
+        llm=llm,
+        cache=InMemoryLRUCache(max_size=2),
+        evaluator=DummyEvaluator(),
+        context_manager=ContextManager(100, type("T", (), {"encode": lambda self, t: t.split()})()),
+        thinking_strategy=NoOpStrategy(),
+    )
+
+    result = await engine.think_and_respond("prompt", alternatives_per_round=1)
+    assert result.response == "initial"


### PR DESCRIPTION
## Summary
- add integration tests for recthink_web_v2 FastAPI routes
- cover RecursiveThinkingEngine JSON parsing and selection edge cases

## Testing
- `flake8 tests/test_recthink_web_v2.py tests/test_recursive_engine_edges.py`
- `pytest tests/test_recthink_web_v2.py tests/test_recursive_engine_edges.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c361bed08333be2997bf7ccebd96