### PR TITLE
Update docs for current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ Example request:
 
 `curl -X POST http://localhost:8000/api/send_message -H "Content-Type: application/json" -d '{"session_id":"sess1","message":"Hello, CoRT!","thinking_rounds":2}'`
 
+### v2 Endpoints
+
+The updated `recthink_web_v2.py` server exposes the following endpoints:
+
+| Method/Path           | Description                            |
+| --------------------- | -------------------------------------- |
+| `POST /chat`          | Run a reasoning cycle and return the final response |
+| `WS   /ws/{session}`  | Interactive WebSocket for single replies |
+| `WS   /ws/stream/{session}` | Stream intermediate thinking updates |
+
 Full API reference available in `docs/API_REFERENCE.md`.
 
 ---
@@ -152,6 +162,11 @@ Full API reference available in `docs/API_REFERENCE.md`.
 ## 🔌 Extending CoRT
 
 Want to integrate a new LLM, cache, or thinking module? Start here:
+
+Current provider classes include:
+- `OpenRouterLLMProvider`
+- `OpenAILLMProvider`
+- `MultiProviderLLM` and `ResilientLLMProvider` for failover setups.
 
 * `docs/EXTENDING.md#custom-providers`
 * `docs/EXTENDING.md#custom-strategies`

--- a/claude/cort-implementation-status.txt
+++ b/claude/cort-implementation-status.txt
@@ -64,10 +64,10 @@ This document clarifies what has been actually implemented in the architecture r
 ## ❌ Not Implemented (Referenced Only)
 
 ### 1. Missing Python Modules
-- ❌ `core/resilience/__init__.py`
+The following init files are now implemented:
+`core/resilience/__init__.py`, `core/security/__init__.py`, and
+`core/providers/__init__.py`.
 - ❌ `core/optimization/__init__.py`
-- ❌ `core/security/__init__.py`
-- ❌ `core/providers/__init__.py` (created but imports non-existent modules)
 
 ### 2. Missing Tests
 - ❌ `tests/test_resilience.py`

--- a/docs/ARCHITECTURE_AUDIT.md
+++ b/docs/ARCHITECTURE_AUDIT.md
@@ -4,6 +4,8 @@
 
 The repository implements an interesting recursive reasoning architecture, but suffers from architectural issues like tight coupling, circular dependencies, poor error handling, and inefficient resource usage. The concept is sound, but the implementation needs refactoring for production readiness.
 
+The current API is served by `recthink_web_v2.py` and offers `/chat` and WebSocket endpoints for streaming updates. Providers include both OpenRouter and OpenAI implementations with a resilient wrapper.
+
 ## Critical Issues & Solutions
 
 ### 1. Architectural Problems


### PR DESCRIPTION
## Summary
- update implementation status
- document v2 API endpoints
- list available provider classes
- clarify architecture audit

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: structlog)*

------
https://chatgpt.com/codex/tasks/task_e_6849c53f5cf88333ab7d8967cc18d958