### PR TITLE
Unify terminology with 'thinking'

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -8,7 +8,7 @@ from .chat_v2 import (
     create_default_engine,
 )
 from .recursion import ConvergenceTracker, TrendConvergenceStrategy
-from .adaptive_reasoning import AdaptiveReasoner
+from .adaptive_thinking import AdaptiveThinkingAgent
 
 __all__ = [
     "CoRTConfig",
@@ -17,5 +17,5 @@ __all__ = [
     "create_default_engine",
     "ConvergenceTracker",
     "TrendConvergenceStrategy",
-    "AdaptiveReasoner",
+    "AdaptiveThinkingAgent",
 ]

--- a/core/adaptive_thinking.py
+++ b/core/adaptive_thinking.py
@@ -8,24 +8,24 @@ from core.interfaces import LLMProvider, QualityEvaluator
 
 
 @dataclass
-class ReasoningState:
+class ThinkingState:
     current_best: str
     confidence: float
     history: List[float] = field(default_factory=list)
     stability_count: int = 0
 
 
-class AdaptiveReasoner:
+class AdaptiveThinkingAgent:
     """Iteratively improve a response with adaptive stopping."""
 
     def __init__(self, llm: LLMProvider, evaluator: QualityEvaluator) -> None:
         self.llm = llm
         self.evaluator = evaluator
 
-    async def reason(self, prompt: str, *, max_rounds: int = 5) -> str:
+    async def think(self, prompt: str, *, max_rounds: int = 5) -> str:
         initial = await self.llm.chat([{"role": "user", "content": prompt}])
         score = self.evaluator.score(initial, prompt)
-        state = ReasoningState(initial, score, [score])
+        state = ThinkingState(initial, score, [score])
 
         for _ in range(1, max_rounds + 1):
             if state.confidence > 0.95 and state.stability_count >= 2:

--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -410,7 +410,7 @@ Respond in this JSON format:
         "2": {{"score": 0-10, "strengths": "...", "weaknesses": "..."}}
     }},
     "selection": "current" or "1" or "2",
-    "reasoning": "Why this option is best"
+    "thinking": "Why this option is best"
 }}"""
 
         messages = self.context_manager.optimize(
@@ -424,7 +424,7 @@ Respond in this JSON format:
             data = json.loads(response.content)
             alternatives = data.get("alternatives", [])[:num_alternatives]
             selection = data.get("selection", "current")
-            reasoning = data.get("reasoning", "No reasoning provided")
+            thinking = data.get("thinking", "No thinking provided")
             
             # Determine selected response
             if selection == "current":
@@ -441,9 +441,9 @@ Respond in this JSON format:
             # Fallback: treat response as single alternative
             alternatives = [response.content]
             best = response.content
-            reasoning = "JSON parsing failed, using raw response"
-            
-        return best, alternatives, reasoning, response.usage["total_tokens"]
+            thinking = "JSON parsing failed, using raw response"
+
+        return best, alternatives, thinking, response.usage["total_tokens"]
         
     async def clear_history(self) -> None:
         """Clear conversation history."""

--- a/docs/ARCHITECTURE_AUDIT.md
+++ b/docs/ARCHITECTURE_AUDIT.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-The repository implements an interesting recursive reasoning architecture, but suffers from architectural issues like tight coupling, circular dependencies, poor error handling, and inefficient resource usage. The concept is sound, but the implementation needs refactoring for production readiness.
+The repository implements an interesting recursive thinking architecture, but suffers from architectural issues like tight coupling, circular dependencies, poor error handling, and inefficient resource usage. The concept is sound, but the implementation needs refactoring for production readiness.
 
 The current API is served by `recthink_web_v2.py` and offers `/chat` and WebSocket endpoints for streaming updates. Providers include both OpenRouter and OpenAI implementations with a resilient wrapper.
 
@@ -14,7 +14,7 @@ The current API is served by `recthink_web_v2.py` and offers `/chat` and WebSock
 
 ### 2. Recursive Algorithm Inefficiencies
 - Currently regenerates alternatives each round without adaptive stopping.
-- Implement an adaptive reasoner with early stopping and parallel generation.
+- Implement an adaptive thinking agent with early stopping and parallel generation.
 
 ### 3. Poor Error Handling & Resilience
 - Add a resilient provider wrapper to handle failures and circuit breaking.
@@ -31,6 +31,6 @@ The current API is served by `recthink_web_v2.py` and offers `/chat` and WebSock
 ## Priority Implementation Roadmap
 
 1. **Critical Fixes**: refactor core class, add resilience, monitoring, and tests.
-2. **Performance Optimization**: adaptive reasoning and improved context management.
+2. **Performance Optimization**: adaptive thinking and improved context management.
 3. **Production Readiness**: documentation, configuration management, and deployment optimization.
 

--- a/tests/test_adaptive_thinking.py
+++ b/tests/test_adaptive_thinking.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 import asyncio  # noqa: E402
 from typing import List, Dict  # noqa: E402
 
-from core.adaptive_reasoning import AdaptiveReasoner  # noqa: E402
+from core.adaptive_thinking import AdaptiveThinkingAgent  # noqa: E402
 from core.interfaces import LLMProvider, QualityEvaluator  # noqa: E402
 
 
@@ -29,13 +29,13 @@ class DummyEval(QualityEvaluator):
         return self.scores.get(response, 0.0)
 
 
-async def run_reasoner():
+async def run_thinker():
     llm = DummyLLM(["bad", "better", "best", "best"])
     evaluator = DummyEval({"bad": 0.1, "better": 0.6, "best": 0.96})
-    reasoner = AdaptiveReasoner(llm, evaluator)
-    return await reasoner.reason("hi", max_rounds=5)
+    thinker = AdaptiveThinkingAgent(llm, evaluator)
+    return await thinker.think("hi", max_rounds=5)
 
 
-def test_adaptive_reasoning_converges():
-    result = asyncio.run(run_reasoner())
+def test_adaptive_thinking_converges():
+    result = asyncio.run(run_thinker())
     assert result == "best"

--- a/tests/test_chat_v2.py
+++ b/tests/test_chat_v2.py
@@ -97,12 +97,12 @@ class TestRecursiveThinkingEngine:
             json.dumps({
                 "alternatives": ["Alt 1", "Alt 2"],
                 "selection": "1",
-                "reasoning": "Alt 1 is better",
+                "thinking": "Alt 1 is better",
             }),
             json.dumps({
                 "alternatives": ["Alt 3", "Alt 4"],
                 "selection": "current",
-                "reasoning": "Current is best",
+                "thinking": "Current is best",
             }),
         ])
         
@@ -315,7 +315,7 @@ class TestIntegration:
                     "2": {"score": 7, "strengths": "Creative", "weaknesses": "Unclear"},
                 },
                 "selection": "1",
-                "reasoning": "The detailed analysis provides more value",
+                "thinking": "The detailed analysis provides more value",
             }),
         ])
         

--- a/tests/test_recursive_engine_edges.py
+++ b/tests/test_recursive_engine_edges.py
@@ -60,7 +60,7 @@ async def test_invalid_json_alternative():
 
 @pytest.mark.asyncio
 async def test_selection_out_of_range():
-    invalid = '{"alternatives": ["a"], "selection": "2", "reasoning": "pick second"}'
+    invalid = '{"alternatives": ["a"], "selection": "2", "thinking": "pick second"}'
     llm = DummyLLM(["initial", invalid])
     engine = RecursiveThinkingEngine(
         llm=llm,


### PR DESCRIPTION
## Summary
- rename AdaptiveReasoner -> AdaptiveThinkingAgent
- replace JSON `reasoning` field with `thinking`
- update docs for thinking terminology
- adjust tests for new class and field names

## Testing
- `flake8 core/adaptive_thinking.py core/__init__.py tests/test_adaptive_thinking.py tests/test_recursive_engine_edges.py tests/test_chat_v2.py`
- `pytest -q` *(fails: assert 500 == 200, KeyError 'hourly_patterns', ProductionSettings load error)*

------
https://chatgpt.com/codex/tasks/task_e_6849c613e2bc83339d0af2a461e6f145