### PR TITLE
Add model policy selector

### DIFF
--- a/core/model_policy.py
+++ b/core/model_policy.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+
+class ModelSelector:
+    """Select models for roles based on a policy with fallbacks."""
+
+    def __init__(self, metadata: Iterable[Dict[str, Any]], policy: Dict[str, str]):
+        self._available = [m.get("id") for m in metadata if m.get("id")]
+        self._available_set = set(self._available)
+        if not self._available:
+            raise ValueError("No model metadata provided")
+        self.policy = policy
+
+    def model_for_role(self, role: str) -> str:
+        preferred = self.policy.get(role)
+        if preferred and preferred in self._available_set:
+            return preferred
+        default = self.policy.get("default")
+        if default and default in self._available_set:
+            return default
+        return self._available[0]
+
+    def map_roles(self, roles: Iterable[str]) -> Dict[str, str]:
+        return {role: self.model_for_role(role) for role in roles}

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -1,0 +1,26 @@
+import pytest
+
+from core.model_policy import ModelSelector
+
+
+def test_selector_prefers_policy_model():
+    metadata = [{"id": "a"}, {"id": "b"}]
+    selector = ModelSelector(metadata, {"assistant": "a"})
+    assert selector.model_for_role("assistant") == "a"
+
+
+def test_selector_falls_back_to_default():
+    metadata = [{"id": "a"}, {"id": "b"}]
+    selector = ModelSelector(metadata, {"critic": "c", "default": "b"})
+    assert selector.model_for_role("critic") == "b"
+
+
+def test_selector_first_available_when_missing():
+    metadata = [{"id": "a"}]
+    selector = ModelSelector(metadata, {"critic": "c"})
+    assert selector.model_for_role("critic") == "a"
+
+
+def test_selector_raises_for_no_models():
+    with pytest.raises(ValueError):
+        ModelSelector([], {"assistant": "a"})


### PR DESCRIPTION
## Summary
- add `ModelSelector` for choosing models based on policy
- test model selector behaviour

## Testing
- `flake8 core/model_policy.py tests/test_model_policy.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6849ff864dcc8333b4ec951aafdac111