### PR TITLE
Add model policy selection

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -269,7 +269,20 @@ class ProductionSettings(BaseSettings):
 def load_production_config() -> ProductionSettings:
     """Load and validate production configuration."""
     try:
-        config = ProductionSettings()
+        data = {
+            "environment": os.getenv("APP_ENV", "production"),
+            "frontend_url": os.getenv("FRONTEND_URL"),
+            "llm": {
+                "primary_model": os.getenv("LLM_PRIMARY_MODEL"),
+                "primary_api_key": os.getenv("LLM_PRIMARY_API_KEY"),
+            },
+            "security": {
+                "api_key_master_key": os.getenv("API_KEY_MASTER_KEY"),
+                "session_secret_key": os.getenv("SESSION_SECRET_KEY"),
+            },
+            "database": {"postgres_url": os.getenv("DATABASE_URL")},
+        }
+        config = ProductionSettings.model_validate(data)
         _validate_runtime_config(config)
         return config
     except Exception as exc:

--- a/monitoring/metrics_v2.py
+++ b/monitoring/metrics_v2.py
@@ -288,9 +288,6 @@ class MetricsAnalyzer:
 
     def get_summary_stats(self) -> Dict[str, Any]:
         """Get summary statistics."""
-        if not self.sessions:
-            return {"status": "no_data"}
-
         recent_sessions = list(self.sessions)[-100:]  # Last 100 sessions
 
         return {

--- a/tests/test_chat_engine.py
+++ b/tests/test_chat_engine.py
@@ -40,6 +40,7 @@ async def test_engine_runs_event_loop():
         evaluator=DummyEvaluator(),
         context_manager=ContextManager(100, tokenizer),
         thinking_strategy=OneRoundStrategy(),
+        model_selector=None,
     )
     result = await engine.think_and_respond('hello', thinking_rounds=1, alternatives_per_round=1)
     assert result.response == 'HELLO'

--- a/tests/test_chat_v2.py
+++ b/tests/test_chat_v2.py
@@ -128,6 +128,7 @@ class TestRecursiveThinkingEngine:
             evaluator=evaluator,
             context_manager=context_manager,
             thinking_strategy=strategy,
+            model_selector=None,
         )
         
         return engine
@@ -347,6 +348,7 @@ class TestIntegration:
             evaluator=evaluator,
             context_manager=context_manager,
             thinking_strategy=strategy,
+            model_selector=None,
         )
         
         # Execute thinking
@@ -395,6 +397,7 @@ class TestIntegration:
             evaluator=evaluator,
             context_manager=context_manager,
             thinking_strategy=strategy,
+            model_selector=None,
         )
         
         # Have a conversation
@@ -412,6 +415,7 @@ class TestIntegration:
             evaluator=evaluator,
             context_manager=context_manager,
             thinking_strategy=strategy,
+            model_selector=None,
         )
         
         await new_engine.load_conversation(str(save_path))

--- a/tests/test_recursive_engine_edges.py
+++ b/tests/test_recursive_engine_edges.py
@@ -51,6 +51,7 @@ async def test_invalid_json_alternative():
         evaluator=DummyEvaluator(),
         context_manager=ContextManager(100, type("T", (), {"encode": lambda self, t: t.split()})()),
         thinking_strategy=NoOpStrategy(),
+        model_selector=None,
     )
 
     result = await engine.think_and_respond("prompt", alternatives_per_round=1)
@@ -68,6 +69,7 @@ async def test_selection_out_of_range():
         evaluator=DummyEvaluator(),
         context_manager=ContextManager(100, type("T", (), {"encode": lambda self, t: t.split()})()),
         thinking_strategy=NoOpStrategy(),
+        model_selector=None,
     )
 
     result = await engine.think_and_respond("prompt", alternatives_per_round=1)


### PR DESCRIPTION
## Summary
- support model policy selection in CoRTConfig
- choose models per role using `ModelSelector`
- load production config from environment explicitly
- keep metrics available even without session data
- adjust tests for new engine constructor

## Testing
- `flake8 core/chat_v2.py tests/test_chat_v2.py tests/test_chat_engine.py tests/test_recursive_engine_edges.py monitoring/metrics_v2.py config/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a006a9b4c8333be4813eed17adb20