### PR TITLE
Add budget management

### DIFF
--- a/core/budget.py
+++ b/core/budget.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from api import fetch_models
+
+
+class BudgetManager:
+    """Track token usage and compute costs for a model."""
+
+    def __init__(self, model: str, token_limit: int, catalog: Optional[List[Dict[str, any]]] = None) -> None:
+        self.model = model
+        self.token_limit = token_limit
+        self.tokens_used = 0
+        self.dollars_spent = 0.0
+
+        catalog = catalog or self._load_catalog()
+        self.pricing = self._find_pricing(catalog)
+        self._cost_per_token = self._compute_cost_per_token()
+
+    @staticmethod
+    def _load_catalog() -> List[Dict[str, any]]:
+        try:
+            return fetch_models()
+        except Exception:
+            return []
+
+    def _find_pricing(self, catalog: List[Dict[str, any]]) -> Dict[str, float]:
+        for entry in catalog:
+            if entry.get("id") == self.model:
+                return entry.get("pricing", {})
+        return {}
+
+    def _compute_cost_per_token(self) -> float:
+        prompt = float(self.pricing.get("prompt", 0))
+        completion = float(self.pricing.get("completion", 0))
+        if prompt == 0 and completion == 0:
+            return 0.0
+        return (prompt + completion) / 1000.0
+
+    def will_exceed_budget(self, next_tokens: int) -> bool:
+        """Return True if adding ``next_tokens`` would exceed the limit."""
+        return self.tokens_used + next_tokens >= self.token_limit
+
+    def record_usage(self, tokens: int) -> None:
+        """Record ``tokens`` consumed and update cost statistics."""
+        self.tokens_used += tokens
+        self.dollars_spent += tokens * self._cost_per_token

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,71 @@
+import pytest
+from typing import Dict, List
+
+from core.budget import BudgetManager
+from core.chat_v2 import RecursiveThinkingEngine, ThinkingStrategy
+from core.context_manager import ContextManager
+from core.providers.cache import InMemoryLRUCache
+from core.interfaces import LLMProvider, QualityEvaluator
+from exceptions import TokenLimitError
+
+
+class DummyLLM(LLMProvider):
+    async def chat(
+        self, messages: List[Dict[str, str]], *, temperature: float = 0.7, **kwargs
+    ):
+        return type(
+            "Resp",
+            (),
+            {
+                "content": messages[-1]["content"],
+                "usage": {"total_tokens": 2},
+                "model": "dummy",
+                "cached": False,
+            },
+        )()
+
+
+class DummyEvaluator(QualityEvaluator):
+    def score(self, response: str, prompt: str) -> float:
+        return 0.0
+
+
+class TwoRoundStrategy(ThinkingStrategy):
+    async def determine_rounds(self, prompt: str) -> int:
+        return 2
+
+    async def should_continue(
+        self, rounds_completed: int, quality_scores: List[float], responses: List[str]
+    ):
+        return rounds_completed < 2, "continue"
+
+
+def test_budget_manager_records_usage():
+    catalog = [{"id": "dummy", "pricing": {"prompt": 0.002, "completion": 0.003}}]
+    manager = BudgetManager("dummy", token_limit=100, catalog=catalog)
+
+    manager.record_usage(50)
+    expected_cost = 50 * (0.002 + 0.003) / 1000
+
+    assert manager.tokens_used == 50
+    assert manager.dollars_spent == pytest.approx(expected_cost)
+
+
+@pytest.mark.asyncio
+async def test_engine_stops_on_budget():
+    budget = BudgetManager("dummy", token_limit=3, catalog=[{"id": "dummy", "pricing": {}}])
+    tokenizer = type("Tok", (), {"encode": lambda self, t: t.split()})()
+    engine = RecursiveThinkingEngine(
+        llm=DummyLLM(),
+        cache=InMemoryLRUCache(max_size=2),
+        evaluator=DummyEvaluator(),
+        context_manager=ContextManager(100, tokenizer),
+        thinking_strategy=TwoRoundStrategy(),
+        model_selector=None,
+        budget_manager=budget,
+    )
+
+    with pytest.raises(TokenLimitError):
+        await engine.think_and_respond("hello", thinking_rounds=2, alternatives_per_round=1)
+
+    assert budget.tokens_used == 2


### PR DESCRIPTION
## Summary
- track token usage and compute costs via `BudgetManager`
- stop thinking when budget would be exceeded
- test budget manager and integration

## Testing
- `flake8 core/budget.py core/chat_v2.py tests/test_budget.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a23f586d083339fc02cdf1405d193