### PR TITLE
Add dynamic model fetch and budget controls

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,13 +1,23 @@
 // API client for RecThink
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000/api';
 
-export const initializeChat = async (apiKey, model) => {
+export const initializeChat = async (
+  apiKey,
+  model,
+  budgetTokenLimit,
+  enforceBudget = true
+) => {
   const response = await fetch(`${API_BASE_URL}/initialize`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ api_key: apiKey, model }),
+    body: JSON.stringify({
+      api_key: apiKey,
+      model,
+      budget_token_limit: budgetTokenLimit,
+      enforce_budget: enforceBudget,
+    }),
   });
   
   if (!response.ok) {
@@ -77,6 +87,16 @@ export const deleteSession = async (sessionId) => {
     throw new Error(`Failed to delete session: ${response.statusText}`);
   }
   
+  return response.json();
+};
+
+export const getModels = async () => {
+  const response = await fetch(`${API_BASE_URL}/models`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch models: ${response.statusText}`);
+  }
+
   return response.json();
 };
 

--- a/frontend/src/components/RecursiveThinkingInterface.jsx
+++ b/frontend/src/components/RecursiveThinkingInterface.jsx
@@ -11,8 +11,11 @@ const RecursiveThinkingInterface = () => {
     thinkingProcess,
     apiKey,
     model,
+    models,
     thinkingRounds,
     alternativesPerRound,
+    budgetCap,
+    enforceBudget,
     error,
     showThinkingProcess,
     connectionStatus,
@@ -22,6 +25,8 @@ const RecursiveThinkingInterface = () => {
     setThinkingRounds,
     setAlternativesPerRound,
     setShowThinkingProcess,
+    setBudgetCap,
+    setEnforceBudget,
     
     initializeChat,
     sendMessage,
@@ -329,15 +334,19 @@ const RecursiveThinkingInterface = () => {
                 
                 <div className="mb-4">
                   <label className="block text-sm font-medium text-gray-700 mb-1">Model</label>
-                  <select 
+                  <select
                     value={model}
                     onChange={(e) => setModel(e.target.value)}
                     className="w-full p-2 border rounded focus:ring-blue-500 focus:border-blue-500"
                   >
-                    <option value="mistralai/mistral-small-3.1-24b-instruct:free">Mistral Small 3.1 24B</option>
-                    <option value="anthropic/claude-3-opus-20240229">Claude 3 Opus</option>
-                    <option value="anthropic/claude-3-sonnet-20240229">Claude 3 Sonnet</option>
-                    <option value="openai/gpt-4o-2024-05-13">GPT-4o</option>
+                    {models.length === 0 && (
+                      <option value={model}>{model}</option>
+                    )}
+                    {models.map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.id}
+                      </option>
+                    ))}
                   </select>
                 </div>
               </div>
@@ -372,6 +381,29 @@ const RecursiveThinkingInterface = () => {
                     onChange={(e) => setAlternativesPerRound(parseInt(e.target.value, 10))}
                     className="w-full p-2 border rounded focus:ring-blue-500 focus:border-blue-500"
                   />
+                </div>
+
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Job Budget Cap (tokens)</label>
+                  <input
+                    type="number"
+                    min="1000"
+                    value={budgetCap}
+                    onChange={(e) => setBudgetCap(parseInt(e.target.value, 10))}
+                    className="w-full p-2 border rounded focus:ring-blue-500 focus:border-blue-500"
+                  />
+                </div>
+
+                <div className="mb-4">
+                  <label className="flex items-center text-sm font-medium text-gray-700">
+                    <input
+                      type="checkbox"
+                      checked={enforceBudget}
+                      onChange={(e) => setEnforceBudget(e.target.checked)}
+                      className="mr-2 h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
+                    />
+                    Enforce budget limit
+                  </label>
                 </div>
                 
                 <div className="mb-4">

--- a/frontend/src/context/RecThinkContext.js
+++ b/frontend/src/context/RecThinkContext.js
@@ -13,8 +13,11 @@ export const RecThinkProvider = ({ children }) => {
   const [thinkingProcess, setThinkingProcess] = useState(null);
   const [apiKey, setApiKey] = useState('');
   const [model, setModel] = useState('mistralai/mistral-small-3.1-24b-instruct:free');
+  const [models, setModels] = useState([]);
   const [thinkingRounds, setThinkingRounds] = useState('auto');
   const [alternativesPerRound, setAlternativesPerRound] = useState(3);
+  const [budgetCap, setBudgetCap] = useState(100000);
+  const [enforceBudget, setEnforceBudget] = useState(true);
   const [error, setError] = useState(null);
   const [showThinkingProcess, setShowThinkingProcess] = useState(false);
   const [sessions, setSessions] = useState([]);
@@ -25,7 +28,12 @@ export const RecThinkProvider = ({ children }) => {
   const initializeChat = async () => {
     try {
       setError(null);
-      const result = await api.initializeChat(apiKey, model);
+      const result = await api.initializeChat(
+        apiKey,
+        model,
+        budgetCap,
+        enforceBudget
+      );
       setSessionId(result.session_id);
       
       // Initialize with welcome message
@@ -134,6 +142,18 @@ export const RecThinkProvider = ({ children }) => {
     }
   };
 
+  useEffect(() => {
+    const loadModels = async () => {
+      try {
+        const result = await api.getModels();
+        setModels(result.models);
+      } catch (err) {
+        // Ignore fetching errors in UI context
+      }
+    };
+    loadModels();
+  }, []);
+
   // Set up WebSocket listeners when connection is established
   useEffect(() => {
     if (!websocket) return;
@@ -187,8 +207,11 @@ export const RecThinkProvider = ({ children }) => {
     thinkingProcess,
     apiKey,
     model,
+    models,
     thinkingRounds,
     alternativesPerRound,
+    budgetCap,
+    enforceBudget,
     error,
     showThinkingProcess,
     sessions,
@@ -200,6 +223,8 @@ export const RecThinkProvider = ({ children }) => {
     setThinkingRounds,
     setAlternativesPerRound,
     setShowThinkingProcess,
+    setBudgetCap,
+    setEnforceBudget,
     
     // Actions
     initializeChat,


### PR DESCRIPTION
## Summary
- fetch OpenRouter models from backend and expose endpoint
- enhance React context with models and budget options
- load model list in settings and add budget controls

## Testing
- `flake8 recthink_web.py`
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a643208788333b44c36522becacd1