### PR TITLE
Add cost tracking and finalization

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -78,6 +78,32 @@ export const listSessions = async () => {
   return response.json();
 };
 
+export const getCost = async (sessionId) => {
+  const response = await fetch(`${API_BASE_URL}/cost/${sessionId}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch cost: ${response.statusText}`);
+  }
+
+  return response.json();
+};
+
+export const finalizeSession = async (sessionId) => {
+  const response = await fetch(`${API_BASE_URL}/finalize`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ session_id: sessionId }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to finalize session: ${response.statusText}`);
+  }
+
+  return response.json();
+};
+
 export const deleteSession = async (sessionId) => {
   const response = await fetch(`${API_BASE_URL}/sessions/${sessionId}`, {
     method: 'DELETE',

--- a/frontend/src/components/RecursiveThinkingInterface.jsx
+++ b/frontend/src/components/RecursiveThinkingInterface.jsx
@@ -19,6 +19,7 @@ const RecursiveThinkingInterface = () => {
     error,
     showThinkingProcess,
     connectionStatus,
+    cost,
     
     setApiKey,
     setModel,
@@ -27,10 +28,11 @@ const RecursiveThinkingInterface = () => {
     setShowThinkingProcess,
     setBudgetCap,
     setEnforceBudget,
-    
+
     initializeChat,
     sendMessage,
-    saveConversation
+    saveConversation,
+    finalizeSession
   } = useRecThink();
   
   const [input, setInput] = useState('');
@@ -230,18 +232,32 @@ const RecursiveThinkingInterface = () => {
           </div>
           
           <div className="flex items-center">
-            {sessionId && (
-              <div className="flex items-center text-sm mr-4">
-                <span className={`inline-block w-2 h-2 mr-1 rounded-full ${
-                  connectionStatus === 'connected' ? 'bg-green-500' : 
-                  connectionStatus === 'error' ? 'bg-red-500' : 'bg-gray-500'
-                }`}></span>
-                <span className="text-gray-600">
-                  {connectionStatus === 'connected' ? 'Connected' : 
-                   connectionStatus === 'error' ? 'Connection error' : 'Disconnected'}
-                </span>
+          {sessionId && (
+            <div className="flex items-center text-sm mr-4">
+              <span className={`inline-block w-2 h-2 mr-1 rounded-full ${
+                connectionStatus === 'connected' ? 'bg-green-500' :
+                connectionStatus === 'error' ? 'bg-red-500' : 'bg-gray-500'
+              }`}></span>
+              <span className="text-gray-600">
+                {connectionStatus === 'connected' ? 'Connected' :
+                 connectionStatus === 'error' ? 'Connection error' : 'Disconnected'}
+              </span>
+            </div>
+          )}
+
+          {sessionId && (
+            <div className="flex items-center mr-4 w-32">
+              <div className="flex-1 bg-gray-200 rounded h-2 mr-2 overflow-hidden">
+                <div
+                  className="bg-blue-500 h-2"
+                  style={{ width: `${(cost.tokensUsed / cost.tokenLimit) * 100}%` }}
+                ></div>
               </div>
-            )}
+              <span className="text-xs text-gray-600">
+                ${cost.dollarsSpent.toFixed(4)}
+              </span>
+            </div>
+          )}
             
             <button 
               className="flex items-center text-sm text-gray-600 hover:text-blue-600 mr-4"
@@ -252,12 +268,20 @@ const RecursiveThinkingInterface = () => {
               Thinking rounds: {thinkingProcess ? thinkingProcess.rounds : '?'}
             </button>
             
-            <button 
+            <button
               className="flex items-center text-sm bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded"
               onClick={() => setActiveTab('settings')}
             >
               <Settings size={14} className="mr-1" />
               Settings
+            </button>
+
+            <button
+              className="ml-2 text-sm bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded"
+              onClick={finalizeSession}
+              disabled={!sessionId}
+            >
+              Stop &amp; Finalize
             </button>
           </div>
         </header>


### PR DESCRIPTION
## Summary
- add summarize_history method to engine
- expose /api/finalize backend route
- display cost metrics and progress bar in chat UI
- add Stop & Finalize button
- track cost in context provider
- update API helpers

## Testing
- `flake8 core/chat_v2.py recthink_web.py`
- `flake8 frontend/src`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a65b65b2083339ea1efd757e1cb8d