### PR TITLE
Add tests for model policy and budget enforcement

### DIFF
--- a/tests/test_budget_enforcement.py
+++ b/tests/test_budget_enforcement.py
@@ -1,0 +1,41 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+import pytest  # noqa: E402
+from core.budget import BudgetManager  # noqa: E402
+
+
+def test_budget_manager_loads_catalog(monkeypatch):
+    calls = {}
+
+    def fake_fetch():
+        calls['called'] = True
+        return [{
+            "id": "m",
+            "pricing": {"prompt": 0.001, "completion": 0.002}
+        }]
+
+    monkeypatch.setattr('core.budget.fetch_models', fake_fetch)
+    manager = BudgetManager('m', token_limit=10)
+    assert calls.get('called') is True
+
+    manager.record_usage(5)
+    expected = 5 * (0.001 + 0.002) / 1000
+    assert manager.dollars_spent == pytest.approx(expected)
+
+
+def test_will_exceed_budget(monkeypatch):
+    monkeypatch.setattr(
+        BudgetManager,
+        '_compute_cost_per_token',
+        lambda self: 0.01,
+    )
+    manager = BudgetManager('x', token_limit=5, catalog=[{'id': 'x'}])
+
+    assert not manager.will_exceed_budget(4)
+    assert manager.will_exceed_budget(5)
+
+    manager.record_usage(4)
+    assert manager.tokens_used == 4
+    assert manager.dollars_spent == pytest.approx(0.04)
+    assert manager.will_exceed_budget(1)

--- a/tests/test_model_policy_decisions.py
+++ b/tests/test_model_policy_decisions.py
@@ -1,0 +1,11 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+from core.model_policy import ModelSelector  # noqa: E402
+
+
+def test_map_roles_with_default():
+    metadata = [{"id": "a"}, {"id": "b"}]
+    selector = ModelSelector(metadata, {"assistant": "b", "default": "a"})
+    result = selector.map_roles(["assistant", "critic"])
+    assert result == {"assistant": "b", "critic": "a"}


### PR DESCRIPTION
## Summary
- add test for ModelSelector.map_roles
- add budget enforcement tests covering catalog fetch and token limit behavior

## Testing
- `flake8 tests/test_model_policy_decisions.py tests/test_budget_enforcement.py`
- `pytest tests/test_model_policy_decisions.py tests/test_budget_enforcement.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a69311db08333b52e70f66f96642b