### PR TITLE
Introduce optimized engine factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,14 @@ Current provider classes include:
 Pass a policy mapping when creating `CoRTConfig`:
 
 ```python
-from core.chat_v2 import CoRTConfig, create_default_engine
+from core.chat_v2 import CoRTConfig
+from core.recursive_engine_v2 import create_optimized_engine
 
 config = CoRTConfig(
     api_key="KEY",
     model_policy={"assistant": "gpt-3.5-turbo", "critic": "gpt-4"},
 )
-engine = create_default_engine(config)
+engine = create_optimized_engine(config)
 ```
 
 * `docs/EXTENDING.md#custom-providers`

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from core.chat_v2 import CoRTConfig, create_default_engine
+from core.chat_v2 import CoRTConfig
+from core.recursive_engine_v2 import create_optimized_engine
 from config import settings
 
 
@@ -20,7 +21,7 @@ async def main() -> None:
         return
 
     config = CoRTConfig(api_key=api_key, model=settings.model)
-    engine = create_default_engine(config)
+    engine = create_optimized_engine(config)
 
     print("\nChat initialized! Type 'exit' to quit, 'save' to save conversation.")
     print("The AI will think recursively before each response.\n")

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -7,6 +7,7 @@ from .chat_v2 import (
     AdaptiveThinkingStrategy,
     create_default_engine,
 )
+from .recursive_engine_v2 import create_optimized_engine
 from .recursion import ConvergenceTracker, TrendConvergenceStrategy
 from .adaptive_thinking import AdaptiveThinkingAgent
 
@@ -15,6 +16,7 @@ __all__ = [
     "RecursiveThinkingEngine",
     "AdaptiveThinkingStrategy",
     "create_default_engine",
+    "create_optimized_engine",
     "ConvergenceTracker",
     "TrendConvergenceStrategy",
     "AdaptiveThinkingAgent",

--- a/recthink_web_v2.py
+++ b/recthink_web_v2.py
@@ -8,11 +8,10 @@ from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from core.chat_v2 import (
-    CoRTConfig,
-    ThinkingResult,
-    RecursiveThinkingEngine,
-    create_default_engine,
+from core.chat_v2 import CoRTConfig, ThinkingResult
+from core.recursive_engine_v2 import (
+    OptimizedRecursiveEngine,
+    create_optimized_engine,
 )
 
 app = FastAPI(title="RecThink API v2")
@@ -26,7 +25,7 @@ app.add_middleware(
 )
 
 # Global store for chat engines per session
-chat_sessions: Dict[str, "RecursiveThinkingEngine"] = {}
+chat_sessions: Dict[str, "OptimizedRecursiveEngine"] = {}
 
 
 class ChatRequest(BaseModel):
@@ -39,7 +38,7 @@ class ChatRequest(BaseModel):
 @app.post("/chat")
 async def chat_endpoint(request: ChatRequest):
     if request.session_id not in chat_sessions:
-        chat_sessions[request.session_id] = create_default_engine(CoRTConfig())
+        chat_sessions[request.session_id] = create_optimized_engine(CoRTConfig())
 
     engine = chat_sessions[request.session_id]
     try:
@@ -66,7 +65,7 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
     await websocket.accept()
 
     if session_id not in chat_sessions:
-        chat_sessions[session_id] = create_default_engine(CoRTConfig())
+        chat_sessions[session_id] = create_optimized_engine(CoRTConfig())
 
     engine = chat_sessions[session_id]
 
@@ -112,7 +111,7 @@ async def websocket_stream(websocket: WebSocket, session_id: str):
     await websocket.accept()
 
     if session_id not in chat_sessions:
-        chat_sessions[session_id] = create_default_engine(CoRTConfig())
+        chat_sessions[session_id] = create_optimized_engine(CoRTConfig())
 
     engine = chat_sessions[session_id]
 

--- a/tests/test_recthink_web_v2.py
+++ b/tests/test_recthink_web_v2.py
@@ -41,7 +41,7 @@ def setup_module(module):
 
 def test_chat_endpoint(monkeypatch):
     client = TestClient(recthink_web_v2.app)
-    monkeypatch.setattr(recthink_web_v2, "create_default_engine", lambda config: DummyEngine())
+    monkeypatch.setattr(recthink_web_v2, "create_optimized_engine", lambda config: DummyEngine())
 
     resp = client.post("/chat", json={"session_id": "s1", "message": "hi"})
     assert resp.status_code == 200
@@ -53,7 +53,7 @@ def test_chat_endpoint(monkeypatch):
 
 def test_websocket_endpoint(monkeypatch):
     client = TestClient(recthink_web_v2.app)
-    monkeypatch.setattr(recthink_web_v2, "create_default_engine", lambda config: DummyEngine())
+    monkeypatch.setattr(recthink_web_v2, "create_optimized_engine", lambda config: DummyEngine())
 
     with client.websocket_connect("/ws/s2") as ws:
         ws.send_text(json.dumps({"message": "hello"}))
@@ -64,7 +64,7 @@ def test_websocket_endpoint(monkeypatch):
 
 def test_websocket_stream(monkeypatch):
     client = TestClient(recthink_web_v2.app)
-    monkeypatch.setattr(recthink_web_v2, "create_default_engine", lambda config: DummyEngine())
+    monkeypatch.setattr(recthink_web_v2, "create_optimized_engine", lambda config: DummyEngine())
 
     with client.websocket_connect("/ws/stream/s3") as ws:
         ws.send_text(json.dumps({"message": "hi"}))


### PR DESCRIPTION
## Summary
- add `create_optimized_engine` to build `OptimizedRecursiveEngine`
- expose the new factory in `core.__init__`
- switch web API v2 and CLI to use optimized engine
- update README usage example
- adjust tests for new factory

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_684ac5e23138833381ad32e131923900