### PR TITLE
Update README to use recthink_web_v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This enables:
    See `config/config.py` for all available options.
 
 3. Run server
-   `uvicorn recthink_web:app --reload`
+   `uvicorn recthink_web_v2:app --reload`
 
 For CLI mode, frontend setup, and advanced options, see `docs/USAGE.md`.
 
@@ -135,7 +135,7 @@ graph TB
 
 ⚠️ **Note**: CoRT is transitioning from a v1 monolith to a clean v2 architecture.
 
-* **Current API**: `recthink_web.py` still runs on legacy v1 logic
+* **Current API**: `recthink_web_v2.py` still runs on legacy v1 logic
 * **v2 Core Engine**: `core/chat_v2.py` is modular and ready
 * **Migration Guide**: See `claude/cort-migration-guide.txt`
 


### PR DESCRIPTION
## Summary
- update quick start instructions for server
- note v2 API file in architecture section

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.optimization')*

------
https://chatgpt.com/codex/tasks/task_e_684ace1f347c83339ee98671fabd6b5d