### PR TITLE
Update API customization tests for v2

### DIFF
--- a/tests/test_api_customization.py
+++ b/tests/test_api_customization.py
@@ -5,79 +5,73 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
 from starlette.testclient import TestClient  # noqa: E402
 
-import recthink_web  # noqa: E402
+import recthink_web_v2  # noqa: E402
+from core.chat_v2 import ThinkingResult  # noqa: E402
 
 
-def setup_session(client):
-    resp = client.post("/api/initialize", json={"api_key": "x", "model": "m"})
-    assert resp.status_code == 200
-    return resp.json()["session_id"]
+class DummyEngine:
+    def __init__(self):
+        self.captured = {}
 
-
-def test_send_message_custom_rounds(monkeypatch):
-    client = TestClient(recthink_web.app)
-    session_id = setup_session(client)
-
-    captured = {}
-
-    async def fake_think(
-        msg,
-        verbose=True,
+    async def think_and_respond(
+        self,
+        message,
         thinking_rounds=None,
         alternatives_per_round=3,
     ):
-        captured["rounds"] = thinking_rounds
-        captured["alts"] = alternatives_per_round
-        return {
-            "response": "ok",
-            "thinking_rounds": thinking_rounds,
-            "thinking_history": [],
-        }
+        self.captured["rounds"] = thinking_rounds
+        self.captured["alts"] = alternatives_per_round
+        return ThinkingResult(
+            response="ok",
+            thinking_rounds=thinking_rounds if thinking_rounds is not None else 3,
+            thinking_history=[],
+            total_tokens=0,
+            processing_time=0.0,
+            convergence_reason="done",
+            metadata={},
+        )
 
-    recthink_web.engine_instances[session_id].think_and_respond = fake_think
+
+def test_send_message_custom_rounds(monkeypatch):
+    engine = DummyEngine()
+    monkeypatch.setattr(
+        recthink_web_v2,
+        "create_optimized_engine",
+        lambda config: engine,
+    )
+
+    client = TestClient(recthink_web_v2.app)
 
     resp = client.post(
-        "/api/send_message",
+        "/chat",
         json={
-            "session_id": session_id,
+            "session_id": "s1",
             "message": "hi",
             "thinking_rounds": 2,
             "alternatives_per_round": 4,
         },
     )
     assert resp.status_code == 200
-    assert captured["rounds"] == 2
-    assert captured["alts"] == 4
+    assert engine.captured["rounds"] == 2
+    assert engine.captured["alts"] == 4
     assert resp.json()["thinking_rounds"] == 2
 
 
 def test_send_message_defaults(monkeypatch):
-    client = TestClient(recthink_web.app)
-    session_id = setup_session(client)
+    engine = DummyEngine()
+    monkeypatch.setattr(
+        recthink_web_v2,
+        "create_optimized_engine",
+        lambda config: engine,
+    )
 
-    captured = {}
-
-    async def fake_think(
-        msg,
-        verbose=True,
-        thinking_rounds=None,
-        alternatives_per_round=3,
-    ):
-        captured["rounds"] = thinking_rounds
-        captured["alts"] = alternatives_per_round
-        return {
-            "response": "ok",
-            "thinking_rounds": 3,
-            "thinking_history": [],
-        }
-
-    recthink_web.engine_instances[session_id].think_and_respond = fake_think
+    client = TestClient(recthink_web_v2.app)
 
     resp = client.post(
-        "/api/send_message",
-        json={"session_id": session_id, "message": "hi"},
+        "/chat",
+        json={"session_id": "s2", "message": "hi"},
     )
     assert resp.status_code == 200
-    assert captured["rounds"] is None
-    assert captured["alts"] == 3
+    assert engine.captured["rounds"] is None
+    assert engine.captured["alts"] == 3
     assert resp.json()["thinking_rounds"] == 3


### PR DESCRIPTION
## Summary
- exercise OptimizedRecursiveEngine via the v2 web API in tests

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684af5675f1083339908e8efeb11da60