### PR TITLE
Implement OpenAI streaming in LLM provider

### DIFF
--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -47,3 +47,64 @@ async def test_openai_llm_provider_chat(monkeypatch):
     assert isinstance(resp, StandardLLMResponse)
     assert resp.content == "ok"
     assert resp.model == "m"
+
+
+@pytest.mark.asyncio
+async def test_openai_llm_provider_stream(monkeypatch):
+    class FakeStream:
+        def __init__(self):
+            self.chunks = [
+                types.SimpleNamespace(
+                    choices=[
+                        types.SimpleNamespace(
+                            delta=types.SimpleNamespace(content="he")
+                        )
+                    ]
+                ),
+                types.SimpleNamespace(
+                    choices=[
+                        types.SimpleNamespace(
+                            delta=types.SimpleNamespace(content="llo")
+                        )
+                    ]
+                ),
+            ]
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self.chunks:
+                raise StopAsyncIteration
+            return self.chunks.pop(0)
+
+    class FakeChatCompletions:
+        async def create(
+            self, model, messages, temperature=0.7, max_tokens=None, stream=False
+        ):
+            if stream:
+                return FakeStream()
+            return types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(
+                        message=types.SimpleNamespace(content="ok")
+                    )
+                ],
+                usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            )
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = types.SimpleNamespace(completions=FakeChatCompletions())
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("core.providers.llm.openai.AsyncOpenAI", FakeClient)
+    provider = OpenAILLMProvider(api_key="k", model="m")
+    output = []
+    async with provider as llm:
+        async for chunk in llm.stream_chat([{"role": "user", "content": "hi"}]):
+            output.append(chunk)
+
+    assert "".join(output) == "hello"


### PR DESCRIPTION
## Summary
- implement streaming support in `OpenAILLMProvider` using OpenAI client
- add unit test covering streaming behavior with a fake OpenAI client

## Testing
- `flake8`
- `PYTHONPATH=. pytest tests/test_llm_provider.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684afa38d86083339fca4aa51a3eefc6