### PR TITLE
Improve Redis cache provider

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,6 +4,8 @@ import types
 import asyncio
 
 import pytest
+import importlib.util
+import os
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, ROOT)
@@ -15,6 +17,7 @@ class FakeRedis:
         self.store = {}
         self.sets = {}
         self.ttl = {}
+        self.expire_calls = []
 
     async def get(self, key):
         exp = self.ttl.get(key)
@@ -51,7 +54,10 @@ class FakeRedis:
         return set(self.sets.get(name, set()))
 
     async def expire(self, name, ttl):
-        # TTL handling not needed for tests
+        self.expire_calls.append((name, ttl))
+        return True
+
+    async def ping(self):
         return True
 
     async def flushdb(self):
@@ -68,14 +74,41 @@ class FakeRedis:
 
 
 def setup_fake_aioredis(monkeypatch):
-    fake_mod = types.SimpleNamespace(from_url=lambda url: FakeRedis())
+    class FakeConnectionPool:
+        def __init__(self, url):
+            self.url = url
+
+        @classmethod
+        def from_url(cls, url):
+            return cls(url)
+
+    class FakeRedisWrapper(FakeRedis):
+        def __init__(self, connection_pool=None):
+            super().__init__()
+            self.connection_pool = connection_pool
+
+    fake_mod = types.SimpleNamespace(
+        ConnectionPool=FakeConnectionPool,
+        Redis=FakeRedisWrapper,
+        from_url=lambda url: FakeRedisWrapper(),
+    )
     monkeypatch.setitem(sys.modules, "aioredis", fake_mod)
+
+
+def get_provider_class():
+    path = os.path.join(ROOT, "core", "providers", "cache.py")
+    name = "cache"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod.RedisCacheProvider
 
 
 @pytest.mark.asyncio
 async def test_set_get(monkeypatch):
     setup_fake_aioredis(monkeypatch)
-    from core.providers.cache import RedisCacheProvider
+    RedisCacheProvider = get_provider_class()
 
     cache = RedisCacheProvider("redis://localhost")
     await cache.set("k", "v")
@@ -85,7 +118,7 @@ async def test_set_get(monkeypatch):
 @pytest.mark.asyncio
 async def test_delete(monkeypatch):
     setup_fake_aioredis(monkeypatch)
-    from core.providers.cache import RedisCacheProvider
+    RedisCacheProvider = get_provider_class()
 
     cache = RedisCacheProvider("redis://localhost")
     await cache.set("k", "v")
@@ -96,7 +129,7 @@ async def test_delete(monkeypatch):
 @pytest.mark.asyncio
 async def test_clear_by_tag(monkeypatch):
     setup_fake_aioredis(monkeypatch)
-    from core.providers.cache import RedisCacheProvider
+    RedisCacheProvider = get_provider_class()
 
     cache = RedisCacheProvider("redis://localhost")
     await cache.set("a", 1, tags=["t1"])
@@ -113,10 +146,42 @@ async def test_clear_by_tag(monkeypatch):
 @pytest.mark.asyncio
 async def test_stats(monkeypatch):
     setup_fake_aioredis(monkeypatch)
-    from core.providers.cache import RedisCacheProvider
+    RedisCacheProvider = get_provider_class()
 
     cache = RedisCacheProvider("redis://localhost")
     await cache.set("a", 1)
     stats = await cache.stats()
     assert stats["entry_count"] == 1
     assert stats["type"] == "redis"
+
+
+@pytest.mark.asyncio
+async def test_ping(monkeypatch):
+    setup_fake_aioredis(monkeypatch)
+    RedisCacheProvider = get_provider_class()
+
+    cache = RedisCacheProvider("redis://localhost")
+    assert await cache.ping() is True
+
+
+@pytest.mark.asyncio
+async def test_tag_ttl_propagation(monkeypatch):
+    setup_fake_aioredis(monkeypatch)
+    RedisCacheProvider = get_provider_class()
+
+    cache = RedisCacheProvider("redis://localhost")
+    await cache.set("k", "v", ttl=10, tags=["t1"])
+
+    key_tags = cache._key_tags("k")
+    tag_set = cache._tag_set("t1")
+    assert (key_tags, 10) in cache.redis.expire_calls
+    assert (tag_set, 10) in cache.redis.expire_calls
+
+
+def test_connection_pool(monkeypatch):
+    setup_fake_aioredis(monkeypatch)
+    RedisCacheProvider = get_provider_class()
+
+    cache = RedisCacheProvider("redis://localhost")
+    assert cache.pool.url == "redis://localhost"
+    assert cache.redis.connection_pool == cache.pool


### PR DESCRIPTION
## Summary
- add connection pooling to `RedisCacheProvider`
- propagate tag TTLs via `expire`
- provide a `ping` method for Redis health checks
- expand unit tests for Redis caching

## Testing
- `flake8 core/providers/cache.py tests/test_cache.py`
- `pytest tests/test_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684afa385fb88333900faef60f011ccc