### PR TITLE
Update dashboard metrics and add monitoring docs

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,14 @@
+# Monitoring Setup
+
+This project exposes metrics via Prometheus using the OpenTelemetry SDK.
+Grafana can be used to visualize these metrics with the provided dashboard.
+
+## Import the Dashboard
+
+1. Start Grafana and ensure the Prometheus data source is configured.
+2. Navigate to **Dashboards → Import**.
+3. Upload `monitoring/dashboards/cort_dashboard.json` or paste its contents.
+4. Select your Prometheus data source if prompted and click **Import**.
+
+The dashboard displays request latency, convergence details and other
+metrics from `metrics_v2.py`.

--- a/monitoring/dashboards/cort_dashboard.json
+++ b/monitoring/dashboards/cort_dashboard.json
@@ -513,13 +513,203 @@
         }
       },
       "targets": [
+    {
+      "expr": "sum by (error_type) (rate(cort_errors_total[5m]))",
+      "refId": "A",
+      "legendFormat": "{{error_type}}"
+    }
+  ],
+  "title": "Error Rate by Type",
+  "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "id": 9,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
         {
-          "expr": "sum by (error_type) (rate(cort_errors_total[5m]))",
+          "expr": "histogram_quantile(0.95, sum(rate(cort_thinking_duration_seconds_bucket[5m])) by (le))",
           "refId": "A",
-          "legendFormat": "{{error_type}}"
+          "legendFormat": "p95"
         }
       ],
-      "title": "Error Rate by Type",
+      "title": "Thinking Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "green", "value": 50 }
+            ]
+          },
+          "unit": "1"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "id": 10,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        { "expr": "cort_active_sessions", "refId": "A" }
+      ],
+      "title": "Active Sessions",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "id": 11,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(cort_quality_improvement_bucket[5m])) by (le))",
+          "refId": "A",
+          "legendFormat": "p95"
+        }
+      ],
+      "title": "Quality Improvement p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "id": 12,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(cort_token_efficiency_bucket[5m])) by (le))",
+          "refId": "A",
+          "legendFormat": "p95"
+        }
+      ],
+      "title": "Token Efficiency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "id": 13,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(cort_provider_latency_seconds_bucket[5m])) by (le, provider))",
+          "refId": "A",
+          "legendFormat": "{{provider}}"
+        }
+      ],
+      "title": "Provider Latency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "unit": "1"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "id": 14,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (provider) (rate(cort_provider_failures_total[5m]))",
+          "refId": "A",
+          "legendFormat": "{{provider}}"
+        }
+      ],
+      "title": "Provider Failures",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
## Summary
- cover more telemetry metrics in `cort_dashboard.json`
- document Grafana dashboard import steps

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_684b0060b3f08333847393f1815a6d9a