### PR TITLE
Add metrics summary endpoint

### DIFF
--- a/recthink_web_v2.py
+++ b/recthink_web_v2.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import asdict
 from typing import Dict, Optional, List
 
@@ -15,7 +16,7 @@ from core.recursive_engine_v2 import (
     OptimizedRecursiveEngine,
     create_optimized_engine,
 )
-from monitoring.metrics_v2 import MetricsAnalyzer
+from monitoring.metrics_v2 import MetricsAnalyzer, ThinkingMetrics
 
 app = FastAPI(title="RecThink API v2")
 
@@ -47,6 +48,7 @@ async def chat_endpoint(request: ChatRequest):
         chat_sessions[request.session_id] = create_optimized_engine(CoRTConfig())
 
     engine = chat_sessions[request.session_id]
+    start_time = time.time()
     try:
         result: ThinkingResult = await engine.think_and_respond(
             request.message,
@@ -55,6 +57,19 @@ async def chat_endpoint(request: ChatRequest):
         )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    end_time = time.time()
+    metrics = ThinkingMetrics(
+        session_id=request.session_id,
+        start_time=start_time,
+        end_time=end_time,
+        rounds_completed=result.thinking_rounds,
+        convergence_reason=result.convergence_reason,
+        quality_scores=[r.quality_score for r in result.thinking_history],
+        round_durations=[r.duration for r in result.thinking_history],
+        alternatives_generated=[len(r.alternatives) for r in result.thinking_history],
+    )
+    metrics_analyzer.record_session(metrics)
 
     history = [asdict(round) for round in result.thinking_history]
 
@@ -158,6 +173,15 @@ async def websocket_stream(websocket: WebSocket, session_id: str):
         pass
     finally:
         await websocket.close()
+
+
+@app.get("/metrics/summary")
+async def metrics_summary() -> Dict[str, object]:
+    """Return summary statistics and recent anomalies."""
+    return {
+        "summary": metrics_analyzer.get_summary_stats(),
+        "anomalies": list(metrics_analyzer.anomalies),
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- record chat metrics via MetricsAnalyzer
- expose new `/metrics/summary` endpoint
- test metrics summary endpoint

## Testing
- `flake8 recthink_web_v2.py tests/test_monitoring.py`
- `PYTHONPATH=. pytest tests/test_monitoring.py::test_metrics_summary_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_684b005f21e88333898e3241aba91b6f