### PR TITLE
Refactor engine helpers

### DIFF
--- a/core/cache_manager.py
+++ b/core/cache_manager.py
@@ -1,0 +1,75 @@
+"""Helper for caching LLM responses."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Dict, List, Optional
+
+import structlog
+
+from exceptions import TokenLimitError
+from core.interfaces import CacheProvider, LLMProvider, LLMResponse
+from core.model_policy import ModelSelector
+from core.budget import BudgetManager
+
+logger = structlog.get_logger(__name__)
+
+
+class CacheManager:
+    """Encapsulate caching logic for LLM calls."""
+
+    def __init__(
+        self,
+        llm: LLMProvider,
+        cache: CacheProvider,
+        *,
+        budget_manager: Optional[BudgetManager] = None,
+        model_selector: Optional[ModelSelector] = None,
+    ) -> None:
+        self.llm = llm
+        self.cache = cache
+        self.budget_manager = budget_manager
+        self.model_selector = model_selector
+
+    async def chat(
+        self,
+        messages: List[Dict[str, str]],
+        *,
+        temperature: float,
+        role: str,
+    ) -> LLMResponse:
+        """Return cached response or call the LLM."""
+
+        key = self._generate_key(messages, temperature)
+        cached = await self.cache.get(key)
+        if cached:
+            logger.info("cache_hit", key=key[:8])
+            if hasattr(cached, "cached"):
+                cached.cached = True
+            return cached
+
+        if self.model_selector:
+            self.llm.model = self.model_selector.model_for_role(role)
+
+        response = await self.llm.chat(messages, temperature=temperature)
+
+        if self.budget_manager:
+            tokens = response.usage.get("total_tokens", 0)
+            if self.budget_manager.will_exceed_budget(tokens):
+                raise TokenLimitError("Token budget exceeded")
+            self.budget_manager.record_usage(tokens)
+
+        await self.cache.set(key, response, ttl=3600, tags=["llm_response"])
+        return response
+
+    def _generate_key(self, messages: List[Dict[str, str]], temperature: float) -> str:
+        content = json.dumps(
+            {
+                "messages": messages,
+                "temperature": temperature,
+                "model": getattr(self.llm, "model", "unknown"),
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(content.encode()).hexdigest()

--- a/core/conversation.py
+++ b/core/conversation.py
@@ -1,0 +1,66 @@
+"""Manage conversation history for the thinking engine."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Dict, List, Optional
+
+import aiofiles
+
+from core.interfaces import LLMProvider
+from core.context_manager import ContextManager
+from core.budget import BudgetManager
+
+
+class ConversationManager:
+    """Handles conversation history and persistence."""
+
+    def __init__(
+        self,
+        llm: LLMProvider,
+        context_manager: ContextManager,
+        *,
+        budget_manager: Optional[BudgetManager] = None,
+    ) -> None:
+        self.llm = llm
+        self.context_manager = context_manager
+        self.budget_manager = budget_manager
+        self.history: List[Dict[str, str]] = []
+
+    def add(self, role: str, content: str) -> None:
+        self.history.append({"role": role, "content": content})
+        self.history = self.context_manager.optimize(self.history)
+
+    def clear(self) -> None:
+        self.history.clear()
+
+    def get(self) -> List[Dict[str, str]]:
+        return list(self.history)
+
+    async def save(self, filepath: str) -> None:
+        data = {
+            "conversation": self.history,
+            "timestamp": time.time(),
+            "metadata": {"model": getattr(self.llm, "model", "unknown")},
+        }
+        async with aiofiles.open(filepath, "w") as f:
+            await f.write(json.dumps(data, indent=2))
+
+    async def load(self, filepath: str) -> None:
+        async with aiofiles.open(filepath, "r") as f:
+            data = json.loads(await f.read())
+        self.history = data.get("conversation", [])
+
+    async def summarize(self) -> str:
+        if not self.history:
+            return "No conversation yet."
+        messages = self.history + [
+            {"role": "user", "content": "Summarize the conversation so far in a short paragraph."}
+        ]
+        response = await self.llm.chat(messages, temperature=0.5)
+        if self.budget_manager:
+            self.budget_manager.record_usage(
+                response.usage.get("total_tokens", 0)
+            )
+        return response.content

--- a/core/metrics_manager.py
+++ b/core/metrics_manager.py
@@ -1,0 +1,30 @@
+"""Wrapper around MetricsRecorder."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from monitoring.metrics import MetricsRecorder
+
+
+class MetricsManager:
+    """Delegates metrics recording."""
+
+    def __init__(self, recorder: Optional[MetricsRecorder] = None) -> None:
+        self.recorder = recorder
+
+    def record(
+        self,
+        *,
+        processing_time: float,
+        token_usage: int,
+        num_rounds: int,
+        convergence_reason: str,
+    ) -> None:
+        if self.recorder:
+            self.recorder.record_run(
+                processing_time=processing_time,
+                token_usage=token_usage,
+                num_rounds=num_rounds,
+                convergence_reason=convergence_reason,
+            )


### PR DESCRIPTION
## Summary
- modularize the engine helpers
- add cache manager class for LLM caching
- extract conversation history manager
- provide metrics manager wrapper
- wire new managers into the engine

## Testing
- `flake8 core tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684b0eb5f5548333bdd6770a34f98ac4