### PR TITLE
Add runtime strategy system

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ engine = create_optimized_engine(config)
 
 * `docs/EXTENDING.md#custom-providers`
 * `docs/EXTENDING.md#custom-strategies`
+* `docs/STRATEGIES.md` for runtime strategy selection
 
 ---
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -4,9 +4,9 @@
 from .chat_v2 import (
     CoRTConfig,
     RecursiveThinkingEngine,
-    AdaptiveThinkingStrategy,
     create_default_engine,
 )
+from .strategies import AdaptiveThinkingStrategy, load_strategy
 from .recursive_engine_v2 import create_optimized_engine
 from .recursion import ConvergenceStrategy
 from .adaptive_thinking import AdaptiveThinkingAgent
@@ -15,6 +15,7 @@ __all__ = [
     "CoRTConfig",
     "RecursiveThinkingEngine",
     "AdaptiveThinkingStrategy",
+    "load_strategy",
     "create_default_engine",
     "create_optimized_engine",
     "ConvergenceStrategy",

--- a/core/strategies/__init__.py
+++ b/core/strategies/__init__.py
@@ -1,0 +1,13 @@
+"""Thinking strategy implementations and loader."""
+
+from .base import ThinkingStrategy
+from .adaptive import AdaptiveThinkingStrategy
+from .fixed import FixedThinkingStrategy
+from .factory import load_strategy
+
+__all__ = [
+    "ThinkingStrategy",
+    "AdaptiveThinkingStrategy",
+    "FixedThinkingStrategy",
+    "load_strategy",
+]

--- a/core/strategies/adaptive.py
+++ b/core/strategies/adaptive.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import List
+
+import structlog
+
+from core.interfaces import LLMProvider
+
+from .base import ThinkingStrategy
+
+logger = structlog.get_logger(__name__)
+
+
+class AdaptiveThinkingStrategy(ThinkingStrategy):
+    """Adaptive strategy that adjusts based on complexity and quality."""
+
+    def __init__(
+        self,
+        llm: LLMProvider,
+        min_rounds: int = 1,
+        max_rounds: int = 5,
+        quality_threshold: float = 0.95,
+        improvement_threshold: float = 0.01,
+    ) -> None:
+        self.llm = llm
+        self.min_rounds = min_rounds
+        self.max_rounds = max_rounds
+        self.quality_threshold = quality_threshold
+        self.improvement_threshold = improvement_threshold
+
+    async def determine_rounds(self, prompt: str) -> int:
+        """Use the LLM to determine optimal number of rounds."""
+        meta_prompt = (
+            f"Analyze this prompt and determine the optimal number of thinking rounds"
+            f" (1-{self.max_rounds}):\n\n{prompt}\n\n"
+            "Consider:\n- Complexity of the request\n- Need for accuracy\n"
+            "- Type of response required\n\n"
+            f"Respond with just a number between {self.min_rounds} "
+            f"and {self.max_rounds}."
+        )
+        response = await self.llm.chat([
+            {"role": "user", "content": meta_prompt}
+        ], temperature=0.3)
+
+        try:
+            rounds = int("".join(filter(str.isdigit, response.content)))
+            return max(self.min_rounds, min(rounds, self.max_rounds))
+        except (ValueError, TypeError):
+            logger.warning("Failed to parse thinking rounds", response=response.content)
+            return 3
+
+    async def should_continue(
+        self,
+        rounds_completed: int,
+        quality_scores: List[float],
+        responses: List[str],
+    ) -> tuple[bool, str]:
+        """Determine if thinking should continue."""
+        if rounds_completed >= self.max_rounds:
+            return False, "max_rounds_reached"
+
+        if not quality_scores:
+            return True, "no_scores_yet"
+
+        if quality_scores[-1] >= self.quality_threshold:
+            return False, "quality_threshold_met"
+
+        if len(quality_scores) >= 3:
+            recent_scores = quality_scores[-3:]
+            improvement = max(recent_scores) - min(recent_scores)
+            if improvement < self.improvement_threshold:
+                return False, "quality_plateau"
+
+        if len(responses) >= 3 and responses[-1] in responses[:-1]:
+            return False, "oscillation_detected"
+
+        return True, "continue"

--- a/core/strategies/base.py
+++ b/core/strategies/base.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import List, Protocol
+
+
+class ThinkingStrategy(Protocol):
+    """Protocol defining the thinking strategy interface."""
+
+    async def determine_rounds(self, prompt: str) -> int:
+        """Determine number of thinking rounds needed."""
+
+    async def should_continue(
+        self,
+        rounds_completed: int,
+        quality_scores: List[float],
+        responses: List[str],
+    ) -> tuple[bool, str]:
+        """Return whether to continue and the reason."""

--- a/core/strategies/factory.py
+++ b/core/strategies/factory.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from core.interfaces import LLMProvider
+
+from .adaptive import AdaptiveThinkingStrategy
+from .fixed import FixedThinkingStrategy
+from .base import ThinkingStrategy
+
+
+_STRATEGY_MAP = {
+    "adaptive": AdaptiveThinkingStrategy,
+    "fixed": FixedThinkingStrategy,
+}
+
+
+def load_strategy(name: str, llm: LLMProvider, **kwargs) -> ThinkingStrategy:
+    """Load a thinking strategy by name with fallback to adaptive."""
+    cls = _STRATEGY_MAP.get(name.lower(), AdaptiveThinkingStrategy)
+    if cls is FixedThinkingStrategy:
+        return cls(**kwargs)
+    return cls(llm, **kwargs)

--- a/core/strategies/fixed.py
+++ b/core/strategies/fixed.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import List
+
+from .base import ThinkingStrategy
+
+
+class FixedThinkingStrategy(ThinkingStrategy):
+    """Strategy that always runs a fixed number of rounds."""
+
+    def __init__(self, rounds: int = 1) -> None:
+        self.rounds = rounds
+
+    async def determine_rounds(self, prompt: str) -> int:
+        return self.rounds
+
+    async def should_continue(
+        self,
+        rounds_completed: int,
+        quality_scores: List[float],
+        responses: List[str],
+    ) -> tuple[bool, str]:
+        if rounds_completed >= self.rounds:
+            return False, "fixed_rounds_complete"
+        return True, "continue"

--- a/docs/STRATEGIES.md
+++ b/docs/STRATEGIES.md
@@ -1,0 +1,26 @@
+# Thinking Strategies
+
+The project supports multiple strategies for controlling the number of recursive
+thinking rounds. Strategies live in `core.strategies` and can be selected at
+runtime.
+
+## Available Strategies
+
+- **adaptive** – Uses the LLM to decide how many rounds are required and stops
+  early when quality improves little.
+- **fixed** – Runs a fixed number of rounds regardless of quality.
+
+## Selecting a Strategy
+
+`CoRTConfig` has a `thinking_strategy` field which defaults to `"adaptive"`.
+When creating an engine using `create_default_engine`, the provided value is
+resolved by `core.strategies.load_strategy`.
+
+```python
+from core import CoRTConfig, create_default_engine
+
+config = CoRTConfig(thinking_strategy="fixed")
+engine = create_default_engine(config)
+```
+
+Unknown strategy names fall back to the adaptive implementation.

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,35 @@
+import pytest
+from core.strategies import load_strategy, AdaptiveThinkingStrategy, FixedThinkingStrategy
+from core.chat_v2 import CoRTConfig, create_default_engine
+
+
+class DummyLLM:
+    async def chat(self, *args, **kwargs):
+        class Resp:
+            content = "1"
+        return Resp()
+
+
+@pytest.mark.asyncio
+async def test_load_strategy_known():
+    llm = DummyLLM()
+    strat = load_strategy("fixed", llm, rounds=2)
+    assert isinstance(strat, FixedThinkingStrategy)
+    rounds = await strat.determine_rounds("test")
+    assert rounds == 2
+
+
+@pytest.mark.asyncio
+async def test_load_strategy_fallback():
+    llm = DummyLLM()
+    strat = load_strategy("unknown", llm)
+    assert isinstance(strat, AdaptiveThinkingStrategy)
+
+
+@pytest.mark.asyncio
+async def test_engine_strategy_switch():
+    cfg = CoRTConfig(thinking_strategy="fixed")
+    engine = create_default_engine(cfg)
+    assert isinstance(engine.thinking_strategy, FixedThinkingStrategy)
+
+


### PR DESCRIPTION
## Summary
- extract thinking strategies to new `core.strategies` package
- add `load_strategy` factory and fixed/adaptive implementations
- allow selecting strategy via `CoRTConfig`
- document strategy usage
- test strategy loader and engine switching

## Testing
- `flake8 core/__init__.py core/chat_v2.py core/strategies/*.py tests/test_strategies.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_684b13676cb88333a2758014c0021d0d