### PR TITLE
Add token metrics

### DIFF
--- a/monitoring/dashboards/cort_dashboard.json
+++ b/monitoring/dashboards/cort_dashboard.json
@@ -513,24 +513,30 @@
         }
       },
       "targets": [
-    {
-      "expr": "sum by (error_type) (rate(cort_errors_total[5m]))",
-      "refId": "A",
-      "legendFormat": "{{error_type}}"
-    }
-  ],
-  "title": "Error Rate by Type",
-  "type": "timeseries"
+        {
+          "expr": "sum by (error_type) (rate(cort_errors_total[5m]))",
+          "refId": "A",
+          "legendFormat": "{{error_type}}"
+        }
+      ],
+      "title": "Error Rate by Type",
+      "type": "timeseries"
     },
     {
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "linear",
-            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
             "spanNulls": true
           },
           "mappings": [],
@@ -538,11 +544,21 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
       "id": 9,
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -561,22 +577,38 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 10 },
-              { "color": "green", "value": 50 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
             ]
           },
           "unit": "1"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
       "id": 10,
       "options": {
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "showThresholdLabels": false,
@@ -585,7 +617,10 @@
       },
       "pluginVersion": "8.0.0",
       "targets": [
-        { "expr": "cort_active_sessions", "refId": "A" }
+        {
+          "expr": "cort_active_sessions",
+          "refId": "A"
+        }
       ],
       "title": "Active Sessions",
       "type": "gauge"
@@ -594,11 +629,17 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "linear",
-            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
             "spanNulls": true
           },
           "mappings": [],
@@ -606,11 +647,21 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
       "id": 11,
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -626,11 +677,17 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "linear",
-            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
             "spanNulls": true
           },
           "mappings": [],
@@ -638,11 +695,21 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
       "id": 12,
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -658,11 +725,17 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "linear",
-            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
             "spanNulls": true
           },
           "mappings": [],
@@ -670,11 +743,21 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
       "id": 13,
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -690,17 +773,29 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "mappings": [],
           "unit": "1"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
       "id": 14,
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -711,12 +806,59 @@
       ],
       "title": "Provider Failures",
       "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 56
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(cort_prompt_tokens_sum[5m]))",
+          "refId": "A",
+          "legendFormat": "prompt"
+        },
+        {
+          "expr": "sum(rate(cort_completion_tokens_sum[5m]))",
+          "refId": "B",
+          "legendFormat": "completion"
+        }
+      ],
+      "title": "Prompt vs Completion Tokens",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
   "schemaVersion": 27,
   "style": "dark",
-  "tags": ["cort", "llm", "monitoring"],
+  "tags": [
+    "cort",
+    "llm",
+    "monitoring"
+  ],
   "templating": {
     "list": []
   },

--- a/monitoring/metrics_v2.py
+++ b/monitoring/metrics_v2.py
@@ -25,6 +25,8 @@ class ThinkingMetrics:
     quality_scores: List[float] = field(default_factory=list)
     round_durations: List[float] = field(default_factory=list)
     token_usage_per_round: List[int] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
     alternatives_generated: List[int] = field(default_factory=list)
     cache_hits: int = 0
     cache_misses: int = 0
@@ -40,7 +42,10 @@ class ThinkingMetrics:
     @property
     def total_tokens(self) -> int:
         """Total tokens used."""
-        return sum(self.token_usage_per_round)
+        total = self.prompt_tokens + self.completion_tokens
+        if total == 0:
+            return sum(self.token_usage_per_round)
+        return total
 
     @property
     def quality_improvement(self) -> float:

--- a/monitoring/telemetry.py
+++ b/monitoring/telemetry.py
@@ -91,6 +91,18 @@ class CoRTMetrics:
             description="Token usage per request",
             unit="1",
         )
+
+        self.prompt_tokens = meter.create_histogram(
+            name="cort_prompt_tokens",
+            description="Prompt tokens per request",
+            unit="1",
+        )
+
+        self.completion_tokens = meter.create_histogram(
+            name="cort_completion_tokens",
+            description="Completion tokens per request",
+            unit="1",
+        )
         
         self.token_efficiency = meter.create_histogram(
             name="cort_token_efficiency",
@@ -372,6 +384,9 @@ def record_thinking_metrics(
     initial_quality: float,
     final_quality: float,
     total_tokens: int,
+    *,
+    prompt_tokens: Optional[int] = None,
+    completion_tokens: Optional[int] = None,
 ) -> None:
     """Record thinking process metrics."""
     metrics = get_metrics()
@@ -382,6 +397,11 @@ def record_thinking_metrics(
     metrics.quality_score.record(final_quality)
     metrics.quality_improvement.record(final_quality - initial_quality)
     metrics.token_usage.record(total_tokens)
+
+    if prompt_tokens is not None:
+        metrics.prompt_tokens.record(prompt_tokens)
+    if completion_tokens is not None:
+        metrics.completion_tokens.record(completion_tokens)
     
     if rounds > 0:
         metrics.token_efficiency.record(total_tokens / rounds)

--- a/recthink_web_v2.py
+++ b/recthink_web_v2.py
@@ -16,11 +16,9 @@ from core.recursive_engine_v2 import (
     OptimizedRecursiveEngine,
     create_optimized_engine,
 )
-codex/add-metrics-analyzer-endpoint-and-tests
 from monitoring.metrics_v2 import MetricsAnalyzer, ThinkingMetrics
 from monitoring.telemetry import initialize_telemetry
 from config.config import load_production_config
-main
 
 app = FastAPI(title="RecThink API v2")
 


### PR DESCRIPTION
## Summary
- track prompt and completion tokens in metrics
- export new metrics via telemetry
- show token trends in Grafana
- test token metrics logic
- clean up stray text in `recthink_web_v2.py`

## Testing
- `flake8 monitoring/metrics_v2.py monitoring/telemetry.py tests/test_monitoring.py recthink_web_v2.py`
- `PYTHONPATH=. pytest tests/test_monitoring.py::TestTelemetry::test_record_token_breakdown -q`
- `PYTHONPATH=. pytest tests/test_monitoring.py::TestThinkingMetrics::test_prompt_completion_tokens -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_684b19cfc3ac8333888ed830bf7fbad0