### PR TITLE
Implement parallel provider ensemble

### DIFF
--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -72,6 +72,8 @@ class CoRTConfig:
     model: str | None = field(default_factory=lambda: settings.model)
     model_policy: Optional[Dict[str, str]] = None
     provider: str = field(default_factory=lambda: settings.llm_provider)
+    providers: Optional[List[str]] = None
+    provider_weights: Optional[List[float]] = None
     max_context_tokens: int = 2000
     cache_size: int = 128
     max_retries: int = 3

--- a/core/model_policy.py
+++ b/core/model_policy.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List, Optional
+
+import asyncio
+
+from core.interfaces import LLMProvider
+from exceptions import APIError
 
 
 class ModelSelector:
@@ -24,3 +29,46 @@ class ModelSelector:
 
     def map_roles(self, roles: Iterable[str]) -> Dict[str, str]:
         return {role: self.model_for_role(role) for role in roles}
+
+
+async def parallel_provider_call(
+    providers: List[LLMProvider],
+    messages: List[Dict[str, str]],
+    *,
+    weights: Optional[List[float]] = None,
+    temperature: float = 0.7,
+    max_tokens: Optional[int] = None,
+) -> Any:
+    """Call providers concurrently and return the highest ranked response."""
+
+    if not providers:
+        raise ValueError("No providers supplied")
+
+    weights = weights or [1.0] * len(providers)
+    if len(weights) != len(providers):
+        raise ValueError("weights length must match providers length")
+
+    async def _call(p: LLMProvider):
+        try:
+            return await p.chat(
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except Exception as exc:  # pragma: no cover - debug logging
+            return exc
+
+    results = await asyncio.gather(*[_call(p) for p in providers])
+
+    scored: List[tuple[float, Any]] = []
+    for weight, result in zip(weights, results):
+        if isinstance(result, Exception):
+            continue
+        score = len(result.content) * weight
+        scored.append((score, result))
+
+    if not scored:
+        raise APIError("All providers failed")
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return scored[0][1]

--- a/tests/test_parallel_providers.py
+++ b/tests/test_parallel_providers.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import importlib.util
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+
+spec = importlib.util.spec_from_file_location(
+    "model_policy", os.path.join(ROOT, "core", "model_policy.py")
+)
+model_policy = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(model_policy)
+
+spec_i = importlib.util.spec_from_file_location(
+    "interfaces", os.path.join(ROOT, "core", "interfaces.py")
+)
+interfaces = importlib.util.module_from_spec(spec_i)
+spec_i.loader.exec_module(interfaces)
+
+import asyncio  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+
+import pytest  # noqa: E402
+
+parallel_provider_call = model_policy.parallel_provider_call  # noqa: E402
+LLMProvider = interfaces.LLMProvider  # noqa: E402
+
+
+class DummyProvider(LLMProvider):
+    def __init__(self, content, fail=False):
+        self.content = content
+        self.fail = fail
+
+    async def chat(self, messages, *, temperature=0.7, max_tokens=None, metadata=None):
+        if self.fail:
+            raise RuntimeError("fail")
+        await asyncio.sleep(0)
+        return SimpleNamespace(content=self.content, usage={"total_tokens": 1}, model="m", cached=False)
+
+    async def stream_chat(self, messages, *, temperature=0.7, max_tokens=None):
+        yield self.content
+
+
+@pytest.mark.asyncio
+async def test_parallel_selects_best():
+    p1 = DummyProvider("short")
+    p2 = DummyProvider("much longer response")
+    result = await parallel_provider_call([p1, p2], [
+        {"role": "user", "content": "hi"}
+    ], weights=[1.0, 0.5])
+    assert result.content == "much longer response"
+
+
+@pytest.mark.asyncio
+async def test_parallel_handles_failure():
+    p1 = DummyProvider("ok", fail=True)
+    p2 = DummyProvider("fine")
+    result = await parallel_provider_call([p1, p2], [
+        {"role": "user", "content": "hi"}
+    ])
+    assert result.content == "fine"


### PR DESCRIPTION
## Summary
- support parallel provider calls with simple ensemble ranking
- expose provider list and weights on `CoRTConfig`
- add tests for parallel provider ensemble

## Testing
- `flake8`
- `pytest tests/test_parallel_providers.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684b19ce9d9c833386d053a4d71f7438