### PR TITLE
Add FAISS memory backend with retrieval

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -150,6 +150,18 @@ class CacheSettings(BaseSettings):
         case_sensitive = False
 
 
+class MemorySettings(BaseSettings):
+    """Vector memory configuration."""
+
+    backend: str = "faiss"
+    index_path: str = "memory.index"
+    embedding_dim: int = 1536
+    retrieval_top_k: int = 3
+
+    class Config:
+        case_sensitive = False
+
+
 class MonitoringSettings(BaseSettings):
     """Monitoring and observability."""
 
@@ -240,6 +252,7 @@ class ProductionSettings(BaseSettings):
     database: DatabaseSettings = Field(default_factory=DatabaseSettings)
     llm: LLMSettings = Field(default_factory=LLMSettings)
     cache: CacheSettings = Field(default_factory=CacheSettings)
+    memory: MemorySettings = Field(default_factory=MemorySettings)
     monitoring: MonitoringSettings = Field(default_factory=MonitoringSettings)
     performance: PerformanceSettings = Field(default_factory=PerformanceSettings)
 

--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -24,12 +24,14 @@ from core.providers import (
     OpenAILLMProvider,
     InMemoryLRUCache,
     EnhancedQualityEvaluator,
+    OpenRouterEmbeddingProvider,
 )
 from core.model_policy import ModelSelector
 from core.budget import BudgetManager
 from core.cache_manager import CacheManager
 from core.metrics_manager import MetricsManager
 from core.conversation import ConversationManager
+from core.memory import FaissMemoryStore
 from api import fetch_models
 from config import settings
 import tiktoken
@@ -79,6 +81,8 @@ class CoRTConfig:
     enable_parallel_thinking: bool = True
     thinking_strategy: str = "adaptive"
     quality_thresholds: Optional[Dict[str, float]] = None
+    memory_dim: int = 1536
+    memory_top_k: int = 3
 
 
 class RecursiveThinkingEngine:
@@ -99,6 +103,7 @@ class RecursiveThinkingEngine:
         metrics_recorder: Optional[MetricsRecorder] = None,
         budget_manager: Optional["BudgetManager"] = None,
         conversation_manager: Optional[ConversationManager] = None,
+        memory_store: Optional["FaissMemoryStore"] = None,
     ) -> None:
         self.llm = llm
         self.cache = cache
@@ -123,6 +128,7 @@ class RecursiveThinkingEngine:
             context_manager,
             budget_manager=budget_manager,
         )
+        self.memory_store = memory_store
         
     async def think_and_respond(
         self,
@@ -156,8 +162,12 @@ class RecursiveThinkingEngine:
         logger.info("thinking_rounds_determined", rounds=thinking_rounds)
         
         # Get initial response
+        memory_context = []
+        if self.memory_store:
+            memory_context = await self.memory_store.retrieve_messages(user_input)
+
         messages = self.context_manager.optimize(
-            self.conversation.get() + [{"role": "user", "content": user_input}]
+            memory_context + self.conversation.get() + [{"role": "user", "content": user_input}]
         )
         
         initial_response = await self.cache_manager.chat(
@@ -345,8 +355,12 @@ Respond in this JSON format:
     "thinking": "Why this option is best"
 }}"""
 
+        memory_context = []
+        if self.memory_store:
+            memory_context = await self.memory_store.retrieve_messages(prompt)
+
         messages = self.context_manager.optimize(
-            self.conversation.get() + [{"role": "user", "content": batch_prompt}]
+            memory_context + self.conversation.get() + [{"role": "user", "content": batch_prompt}]
         )
         
         response = await self.cache_manager.chat(
@@ -440,6 +454,15 @@ def create_default_engine(config: CoRTConfig) -> RecursiveThinkingEngine:
         budget_manager=budget,
     )
 
+    embedding_provider = OpenRouterEmbeddingProvider(
+        api_key=config.api_key or os.getenv("OPENROUTER_API_KEY"),
+    )
+    memory_store = FaissMemoryStore(
+        embedding_provider,
+        config.memory_dim,
+        top_k=config.memory_top_k,
+    )
+
     return RecursiveThinkingEngine(
         llm=llm,
         cache=cache,
@@ -452,4 +475,5 @@ def create_default_engine(config: CoRTConfig) -> RecursiveThinkingEngine:
         metrics_manager=metrics_manager,
         budget_manager=budget,
         conversation_manager=conversation_manager,
+        memory_store=memory_store,
     )

--- a/core/memory/__init__.py
+++ b/core/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Memory backend implementations."""
+
+from .faiss_store import FaissMemoryStore
+
+__all__ = ["FaissMemoryStore"]

--- a/core/memory/faiss_store.py
+++ b/core/memory/faiss_store.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import List, Optional, Dict
+
+import faiss
+import numpy as np
+
+from core.interfaces import EmbeddingProvider
+
+
+class FaissMemoryStore:
+    """Simple FAISS based vector store for conversation memory."""
+
+    def __init__(
+        self,
+        embedding_provider: EmbeddingProvider,
+        dimension: int,
+        *,
+        top_k: int = 3,
+    ) -> None:
+        self.embedding_provider = embedding_provider
+        self.dimension = dimension
+        self.index = faiss.IndexFlatL2(dimension)
+        self.documents: List[Dict[str, str]] = []
+        self.top_k = top_k
+
+    async def add(self, text: str, metadata: Optional[Dict[str, str]] = None) -> None:
+        embedding = await self.embedding_provider.embed([text])
+        vec = np.array(embedding, dtype="float32")
+        self.index.add(vec)
+        self.documents.append({"text": text, "metadata": metadata or {}})
+
+    async def search(self, query: str, top_k: Optional[int] = None) -> List[str]:
+        if self.index.ntotal == 0:
+            return []
+        embedding = await self.embedding_provider.embed([query])
+        vec = np.array(embedding, dtype="float32")
+        k = top_k or self.top_k
+        distances, indices = self.index.search(vec, k)
+        results = []
+        for idx in indices[0]:
+            if 0 <= idx < len(self.documents):
+                results.append(self.documents[idx]["text"])
+        return results
+
+    async def retrieve_messages(
+        self, query: str, top_k: Optional[int] = None
+    ) -> List[Dict[str, str]]:
+        texts = await self.search(query, top_k)
+        return [{"role": "system", "content": t} for t in texts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ opentelemetry-sdk
 opentelemetry-exporter-prometheus
 aiofiles
 aioredis
+faiss-cpu

--- a/tests/test_memory_retrieval.py
+++ b/tests/test_memory_retrieval.py
@@ -1,0 +1,123 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+import types  # noqa: E402
+mock_instr = types.ModuleType("opentelemetry.instrumentation.aiohttp_client")  # noqa: E402
+mock_instr.AioHttpClientInstrumentor = type(
+    "AioHttpClientInstrumentor",
+    (),
+    {"instrument": lambda *a, **k: None, "uninstrument": lambda *a, **k: None},
+)
+sys.modules.setdefault("opentelemetry.instrumentation.aiohttp_client", mock_instr)  # noqa: E402
+mock_req = types.ModuleType("opentelemetry.instrumentation.requests")  # noqa: E402
+mock_req.RequestsInstrumentor = type(
+    "RequestsInstrumentor",
+    (),
+    {"instrument": lambda *a, **k: None, "uninstrument": lambda *a, **k: None},
+)
+sys.modules.setdefault("opentelemetry.instrumentation.requests", mock_req)  # noqa: E402
+
+import pytest  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+from typing import Dict, List  # noqa: E402
+
+from core.chat_v2 import RecursiveThinkingEngine  # noqa: E402
+from core.context_manager import ContextManager  # noqa: E402
+from core.conversation import ConversationManager  # noqa: E402
+from core.recursion import ConvergenceStrategy  # noqa: E402
+from core.providers.cache import InMemoryLRUCache  # noqa: E402
+from core.memory import FaissMemoryStore  # noqa: E402
+
+
+class DummyEmbeddingProvider:
+    async def embed(self, texts: List[str]) -> List[List[float]]:
+        return [[float(len(t))] * 4 for t in texts]
+
+    async def similarity(self, text1: str, text2: str) -> float:
+        return 1.0
+
+
+class MockLLMResponse:
+    def __init__(self, content: str, tokens: int = 10):
+        self.content = content
+        self.usage = {"prompt_tokens": tokens, "completion_tokens": 0, "total_tokens": tokens}
+        self.model = "test"
+        self.cached = False
+
+
+class MemoryAwareLLMProvider:
+    def __init__(self):
+        self.calls = []
+        self.call_count = 0
+
+    async def chat(
+        self,
+        messages: List[Dict[str, str]],
+        *,
+        temperature: float = 0.7,
+        **kwargs
+    ) -> MockLLMResponse:
+        self.calls.append({"messages": messages, "temperature": temperature})
+        self.call_count += 1
+        for msg in messages:
+            if msg["role"] == "system":
+                return MockLLMResponse(msg["content"])
+        return MockLLMResponse("default")
+
+
+class MockQualityEvaluator:
+    def __init__(self):
+        self.thresholds = {"overall": 0.5}
+
+    def score(self, response: str, prompt: str) -> float:
+        return 1.0
+
+
+class MockThinkingStrategy:
+    async def determine_rounds(self, prompt: str) -> int:
+        return 1
+
+    async def should_continue(
+        self,
+        rounds_completed: int,
+        quality_scores: List[float],
+        responses: List[str],
+    ) -> tuple[bool, str]:
+        return False, "complete"
+
+
+@pytest.mark.asyncio
+async def test_memory_influences_response():
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda text: text.split()
+
+    embedding_provider = DummyEmbeddingProvider()
+    memory = FaissMemoryStore(embedding_provider, 4, top_k=1)
+    await memory.add("The capital of France is Paris.")
+
+    llm = MemoryAwareLLMProvider()
+    cache = InMemoryLRUCache()
+    evaluator = MockQualityEvaluator()
+    context_manager = ContextManager(100, tokenizer)
+    conversation = ConversationManager(llm, context_manager)
+    strategy = MockThinkingStrategy()
+    convergence = ConvergenceStrategy(lambda a, b: 1.0, evaluator.score)
+
+    engine = RecursiveThinkingEngine(
+        llm=llm,
+        cache=cache,
+        evaluator=evaluator,
+        context_manager=context_manager,
+        thinking_strategy=strategy,
+        convergence_strategy=convergence,
+        model_selector=None,
+        conversation_manager=conversation,
+        memory_store=memory,
+    )
+
+    result = await engine.think_and_respond("What is the capital of France?")
+
+    assert result.response == "The capital of France is Paris."
+    first_messages = llm.calls[0]["messages"]
+    assert any("Paris" in m["content"] for m in first_messages if m["role"] == "system")


### PR DESCRIPTION
## Summary
- implement `FaissMemoryStore` under `core/memory`
- allow `RecursiveThinkingEngine` to retrieve memory context each round
- expose `MemorySettings` in configuration
- add FAISS dependency
- test that retrieved memory modifies responses

## Testing
- `flake8 core/memory/faiss_store.py core/chat_v2.py config/config.py tests/test_memory_retrieval.py`
- `pytest tests/test_memory_retrieval.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b19cd20c8833384d313a43d4426eb