### PR TITLE
Add CriticLLM provider and integrate critic feedback

### DIFF
--- a/core/providers/__init__.py
+++ b/core/providers/__init__.py
@@ -23,6 +23,7 @@ from .llm import (
     MultiProviderLLM,
 )
 from .quality import EnhancedQualityEvaluator, SimpleQualityEvaluator
+from .critic import CriticLLM
 from .resilient_llm import ResilientLLMProvider
 
 __all__ = [
@@ -44,4 +45,5 @@ __all__ = [
     "EnhancedQualityEvaluator",
     "SimpleQualityEvaluator",
     "ResilientLLMProvider",
+    "CriticLLM",
 ]

--- a/core/providers/critic.py
+++ b/core/providers/critic.py
@@ -1,0 +1,37 @@
+"""LLM-based critic for evaluating and improving responses."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, Optional
+
+from core.interfaces import LLMProvider
+
+
+class CriticLLM:
+    """Wrapper that uses an LLM to critique responses."""
+
+    def __init__(self, llm: LLMProvider) -> None:
+        self.llm = llm
+
+    async def review(self, prompt: str, response: str) -> Dict[str, Optional[str]]:
+        """Return a score and optional improved response."""
+        review_prompt = {
+            "role": "user",
+            "content": (
+                "Given the prompt and response, rate the response from 0 to 1 "
+                "for overall quality. If you can improve it, return an "
+                "'improved' version. Respond with JSON like: "
+                '{"score": 0.5, "improved": "text"}\n\n'
+                f"Prompt: {prompt}\nResponse: {response}"
+            ),
+        }
+        result = await self.llm.chat([review_prompt], temperature=0.0)
+        try:
+            data = json.loads(result.content)
+            score = float(data.get("score", 0))
+            improved = data.get("improved")
+        except Exception:
+            score = 0.0
+            improved = None
+        return {"score": score, "improved": improved}


### PR DESCRIPTION
## Summary
- add a `CriticLLM` wrapper to evaluate and improve responses
- expose `CriticLLM` in provider package
- integrate critic review into `RecursiveThinkingEngine`
- support critic model in `create_default_engine`
- test critic influence on chosen response

## Testing
- `flake8 core/providers/critic.py core/providers/__init__.py core/chat_v2.py tests/test_chat_v2.py`
- `pytest tests/test_chat_v2.py::TestRecursiveThinkingEngine::test_critic_overrides_response -q`

------
https://chatgpt.com/codex/tasks/task_e_684b19cf4a988333a75f2a31d28d0316