### PR TITLE
Add model router and update engine

### DIFF
--- a/core/model_router.py
+++ b/core/model_router.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing
+    from core.chat_v2 import CoRTConfig
+
+from core.model_policy import ModelSelector
+from core.providers import (
+    OpenAILLMProvider,
+    OpenRouterLLMProvider,
+    MultiProviderLLM,
+    LLMProvider,
+)
+
+
+class ModelRouter:
+    """Select providers and models for different roles."""
+
+    def __init__(
+        self,
+        provider: str,
+        api_key: Optional[str] = None,
+        *,
+        providers: Optional[List[str]] = None,
+        provider_weights: Optional[List[float]] = None,
+        model: Optional[str] = None,
+        selector: Optional[ModelSelector] = None,
+        max_retries: int = 3,
+    ) -> None:
+        self.provider = provider
+        self.providers = providers or [provider]
+        self.provider_weights = provider_weights
+        self.api_key = api_key
+        self.model = model
+        self.selector = selector
+        self.max_retries = max_retries
+
+    @classmethod
+    def from_config(
+        cls, config: "CoRTConfig", selector: Optional[ModelSelector] = None
+    ) -> "ModelRouter":
+        return cls(
+            provider=config.provider,
+            api_key=config.api_key,
+            providers=config.providers,
+            provider_weights=config.provider_weights,
+            model=config.model,
+            selector=selector,
+            max_retries=config.max_retries,
+        )
+
+    def model_for_role(self, role: str) -> str:
+        if self.selector:
+            return self.selector.model_for_role(role)
+        return self.model or ""
+
+    def _build_single_provider(self, name: str, model: str) -> LLMProvider:
+        if name.lower() == "openai":
+            return OpenAILLMProvider(
+                api_key=self.api_key or os.getenv("OPENAI_API_KEY"),
+                model=model,
+                max_retries=self.max_retries,
+            )
+        return OpenRouterLLMProvider(
+            api_key=self.api_key or os.getenv("OPENROUTER_API_KEY"),
+            model=model,
+            max_retries=self.max_retries,
+        )
+
+    def provider_for_role(self, role: str) -> LLMProvider:
+        model = self.model_for_role(role)
+        providers = [self._build_single_provider(p, model) for p in self.providers]
+        if len(providers) == 1:
+            return providers[0]
+        return MultiProviderLLM(providers)
+
+    async def provider_health(self) -> Dict[str, bool]:
+        results: Dict[str, bool] = {}
+        ping = [{"role": "system", "content": "ping"}]
+        for name in self.providers:
+            provider = self._build_single_provider(name, self.model_for_role("assistant"))
+            try:
+                async with provider as p:
+                    await p.chat(ping, temperature=0.0, max_tokens=1)
+                results[name] = True
+            except Exception:
+                results[name] = False
+        return results

--- a/core/recursive_engine_v2.py
+++ b/core/recursive_engine_v2.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 from typing import Dict, List, Optional, Tuple
 
 import structlog
@@ -17,10 +16,9 @@ from core.interfaces import (
 )
 from core.chat_v2 import CoRTConfig
 from core.model_policy import ModelSelector
+from core.model_router import ModelRouter
 from api import fetch_models
 from core.providers import (
-    OpenRouterLLMProvider,
-    OpenAILLMProvider,
     InMemoryLRUCache,
     EnhancedQualityEvaluator,
     CriticLLM,
@@ -52,10 +50,11 @@ class OptimizedRecursiveEngine:
 
     def __init__(
         self,
-        llm: LLMProvider,
+        llm: Optional[LLMProvider],
         cache: CacheProvider,
         evaluator: QualityEvaluator,
         *,
+        model_router: Optional[ModelRouter] = None,
         critic: Optional[CriticLLM] = None,
         enable_parallel: bool = True,
         enable_adaptive: bool = True,
@@ -63,7 +62,16 @@ class OptimizedRecursiveEngine:
         max_cache_size: int = 10000,
         convergence_strategy: Optional[ConvergenceStrategy] = None,
     ):
-        self.llm = llm
+        if model_router and llm is None:
+            llm = model_router.provider_for_role("assistant")
+            if critic is None:
+                try:
+                    critic = CriticLLM(model_router.provider_for_role("critic"))
+                except Exception:  # pragma: no cover - optional critic
+                    critic = None
+
+        self.model_router = model_router
+        self.llm = llm  # type: ignore[assignment]
         self.cache = cache
         self.evaluator = evaluator
         self.critic = critic
@@ -361,42 +369,11 @@ def create_optimized_engine(config: CoRTConfig) -> OptimizedRecursiveEngine:
     """Build an :class:`OptimizedRecursiveEngine` from configuration."""
 
     selector: Optional[ModelSelector] = None
-    default_model = config.model
-
     if config.model_policy:
         metadata = fetch_models()
         selector = ModelSelector(metadata, config.model_policy)
-        default_model = selector.model_for_role("assistant")
 
-    if config.provider.lower() == "openai":
-        llm = OpenAILLMProvider(
-            api_key=config.api_key or os.getenv("OPENAI_API_KEY"),
-            model=default_model,
-            max_retries=config.max_retries,
-        )
-    else:
-        llm = OpenRouterLLMProvider(
-            api_key=config.api_key or os.getenv("OPENROUTER_API_KEY"),
-            model=default_model,
-            max_retries=config.max_retries,
-        )
-
-    critic = None
-    if selector:
-        critic_model = selector.model_for_role("critic")
-        if config.provider.lower() == "openai":
-            critic_provider = OpenAILLMProvider(
-                api_key=config.api_key or os.getenv("OPENAI_API_KEY"),
-                model=critic_model,
-                max_retries=config.max_retries,
-            )
-        else:
-            critic_provider = OpenRouterLLMProvider(
-                api_key=config.api_key or os.getenv("OPENROUTER_API_KEY"),
-                model=critic_model,
-                max_retries=config.max_retries,
-            )
-        critic = CriticLLM(critic_provider)
+    router = ModelRouter.from_config(config, selector)
 
     cache = InMemoryLRUCache(max_size=config.cache_size)
 
@@ -408,10 +385,10 @@ def create_optimized_engine(config: CoRTConfig) -> OptimizedRecursiveEngine:
     )
 
     return OptimizedRecursiveEngine(
-        llm=llm,
+        llm=None,
         cache=cache,
         evaluator=evaluator,
-        critic=critic,
+        model_router=router,
         convergence_strategy=convergence,
         enable_parallel=config.enable_parallel_thinking,
     )

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -1,6 +1,71 @@
+import importlib.util
+import importlib
+import pathlib
+import types
+import sys
+from dataclasses import dataclass
 import pytest
 
-from core.model_policy import ModelSelector
+CORE_DIR = pathlib.Path(__file__).resolve().parents[1] / "core"
+
+core_stub = types.ModuleType("core")
+core_stub.interfaces = types.ModuleType("interfaces")
+core_stub.interfaces.LLMProvider = object
+sys.modules.setdefault("core", core_stub)
+sys.modules.setdefault("core.interfaces", core_stub.interfaces)
+exc_stub = types.ModuleType("exceptions")
+exc_stub.APIError = Exception
+sys.modules.setdefault("exceptions", exc_stub)
+providers_stub = types.ModuleType("providers")
+
+
+class DummyProvider:
+    def __init__(self, *args, **kwargs):
+        self.model = kwargs.get("model")
+
+    async def chat(self, messages, **kwargs):
+        return None
+
+
+providers_stub.OpenAILLMProvider = DummyProvider
+providers_stub.OpenRouterLLMProvider = DummyProvider
+providers_stub.MultiProviderLLM = type(
+    "MultiProviderLLM",
+    (),
+    {"__init__": lambda self, providers: setattr(self, "providers", providers)},
+)
+providers_stub.LLMProvider = DummyProvider
+core_stub.providers = providers_stub
+sys.modules.setdefault("core.providers", providers_stub)
+OpenAILLMProvider = providers_stub.OpenAILLMProvider
+MultiProviderLLM = providers_stub.MultiProviderLLM
+
+spec = importlib.util.spec_from_file_location(
+    "model_policy", CORE_DIR / "model_policy.py"
+)
+model_policy = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(model_policy)
+sys.modules["core.model_policy"] = model_policy
+ModelSelector = model_policy.ModelSelector
+
+spec_router = importlib.util.spec_from_file_location(
+    "model_router", CORE_DIR / "model_router.py"
+)
+model_router = importlib.util.module_from_spec(spec_router)
+spec_router.loader.exec_module(model_router)
+sys.modules["core.model_router"] = model_router
+ModelRouter = model_router.ModelRouter
+
+
+@dataclass
+class DummyConfig:
+    provider: str = "openai"
+    api_key: str = "k"
+    model: str = "m"
+    providers: list[str] | None = None
+    provider_weights: list[float] | None = None
+    model_policy: dict | None = None
+    max_retries: int = 3
 
 
 def test_selector_prefers_policy_model():
@@ -24,3 +89,21 @@ def test_selector_first_available_when_missing():
 def test_selector_raises_for_no_models():
     with pytest.raises(ValueError):
         ModelSelector([], {"assistant": "a"})
+
+
+def test_router_selects_provider_and_model():
+    metadata = [{"id": "x"}]
+    selector = ModelSelector(metadata, {"assistant": "x"})
+    cfg = DummyConfig()
+    router = ModelRouter.from_config(cfg, selector)
+    provider = router.provider_for_role("assistant")
+    assert isinstance(provider, OpenAILLMProvider)
+    assert provider.model == "x"
+
+
+def test_router_multi_provider():
+    cfg = DummyConfig(providers=["openai", "openrouter"])
+    router = ModelRouter.from_config(cfg)
+    provider = router.provider_for_role("assistant")
+    assert isinstance(provider, MultiProviderLLM)
+    assert len(provider.providers) == 2

--- a/tests/test_model_policy_decisions.py
+++ b/tests/test_model_policy_decisions.py
@@ -1,7 +1,69 @@
-import os
+import importlib
+import importlib.util
+import pathlib
+import types
 import sys
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
-from core.model_policy import ModelSelector  # noqa: E402
+from dataclasses import dataclass
+import pytest
+
+CORE_DIR = pathlib.Path(__file__).resolve().parents[1] / "core"
+
+core_stub = types.ModuleType("core")
+core_stub.interfaces = types.ModuleType("interfaces")
+core_stub.interfaces.LLMProvider = object
+sys.modules.setdefault("core", core_stub)
+sys.modules.setdefault("core.interfaces", core_stub.interfaces)
+exc_stub = types.ModuleType("exceptions")
+exc_stub.APIError = Exception
+sys.modules.setdefault("exceptions", exc_stub)
+providers_stub = types.ModuleType("providers")
+
+
+class DummyProvider:
+    def __init__(self, *args, **kwargs):
+        self.model = kwargs.get("model")
+
+    async def chat(self, messages, **kwargs):
+        return None
+
+
+providers_stub.OpenAILLMProvider = DummyProvider
+providers_stub.OpenRouterLLMProvider = DummyProvider
+providers_stub.MultiProviderLLM = type(
+    "MultiProviderLLM",
+    (),
+    {"__init__": lambda self, providers: setattr(self, "providers", providers)},
+)
+providers_stub.LLMProvider = DummyProvider
+core_stub.providers = providers_stub
+sys.modules.setdefault("core.providers", providers_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "model_policy", CORE_DIR / "model_policy.py"
+)
+model_policy = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(model_policy)
+sys.modules["core.model_policy"] = model_policy
+ModelSelector = model_policy.ModelSelector
+
+spec_router = importlib.util.spec_from_file_location(
+    "model_router", CORE_DIR / "model_router.py"
+)
+model_router = importlib.util.module_from_spec(spec_router)
+spec_router.loader.exec_module(model_router)
+sys.modules["core.model_router"] = model_router
+ModelRouter = model_router.ModelRouter
+
+
+@dataclass
+class DummyConfig:
+    provider: str = "openai"
+    api_key: str = "k"
+    model: str = "m"
+    providers: list[str] | None = None
+    provider_weights: list[float] | None = None
+    model_policy: dict | None = None
+    max_retries: int = 3
 
 
 def test_map_roles_with_default():
@@ -9,3 +71,21 @@ def test_map_roles_with_default():
     selector = ModelSelector(metadata, {"assistant": "b", "default": "a"})
     result = selector.map_roles(["assistant", "critic"])
     assert result == {"assistant": "b", "critic": "a"}
+
+
+@pytest.mark.asyncio
+async def test_router_health(monkeypatch):
+    async def fake_chat(messages, **kwargs):
+        return type("Resp", (), {"content": "ok"})()
+
+    metadata = [{"id": "a"}]
+    selector = ModelSelector(metadata, {"assistant": "a"})
+    cfg = DummyConfig()
+    router = ModelRouter.from_config(cfg, selector)
+    monkeypatch.setattr(
+        "core.model_router.OpenAILLMProvider.chat",
+        lambda self, m, **kw: fake_chat(m, **kw),
+    )
+
+    health = await router.provider_health()
+    assert health == {"openai": True}


### PR DESCRIPTION
## Summary
- implement `ModelRouter` for provider selection
- refactor `create_optimized_engine` to use ModelRouter
- inject router into `OptimizedRecursiveEngine`
- update model policy tests for router behaviour

## Testing
- `flake8 core/model_router.py core/recursive_engine_v2.py tests/test_model_policy.py tests/test_model_policy_decisions.py`
- `PYTHONPATH=. pytest -q tests/test_model_policy.py tests/test_model_policy_decisions.py`

------
https://chatgpt.com/codex/tasks/task_e_684c76396b5c8333a08af33f85eb07ee