### PR TITLE
Centralize budget tracking

### DIFF
--- a/core/budget.py
+++ b/core/budget.py
@@ -42,7 +42,17 @@ class BudgetManager:
         """Return True if adding ``next_tokens`` would exceed the limit."""
         return self.tokens_used + next_tokens >= self.token_limit
 
-    def record_usage(self, tokens: int) -> None:
+    def enforce_limit(self, next_tokens: int) -> None:
+        """Raise ``TokenLimitError`` if the token budget would be exceeded."""
+        from exceptions import TokenLimitError
+
+        if self.will_exceed_budget(next_tokens):
+            raise TokenLimitError("Token budget exceeded")
+
+    def record_llm_usage(self, tokens: int) -> None:
         """Record ``tokens`` consumed and update cost statistics."""
         self.tokens_used += tokens
         self.dollars_spent += tokens * self._cost_per_token
+
+    # Backwards compatibility
+    record_usage = record_llm_usage

--- a/core/cache_manager.py
+++ b/core/cache_manager.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional
 
 import structlog
 
-from exceptions import TokenLimitError
 from core.interfaces import CacheProvider, LLMProvider, LLMResponse
 from core.model_policy import ModelSelector
 from core.budget import BudgetManager
@@ -56,9 +55,8 @@ class CacheManager:
 
         if self.budget_manager:
             tokens = response.usage.get("total_tokens", 0)
-            if self.budget_manager.will_exceed_budget(tokens):
-                raise TokenLimitError("Token budget exceeded")
-            self.budget_manager.record_usage(tokens)
+            self.budget_manager.enforce_limit(tokens)
+            self.budget_manager.record_llm_usage(tokens)
 
         await self.cache.set(key, response, ttl=3600, tags=["llm_response"])
         return response

--- a/core/conversation.py
+++ b/core/conversation.py
@@ -60,7 +60,7 @@ class ConversationManager:
         ]
         response = await self.llm.chat(messages, temperature=0.5)
         if self.budget_manager:
-            self.budget_manager.record_usage(
-                response.usage.get("total_tokens", 0)
-            )
+            tokens = response.usage.get("total_tokens", 0)
+            self.budget_manager.enforce_limit(tokens)
+            self.budget_manager.record_llm_usage(tokens)
         return response.content

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -46,7 +46,7 @@ def test_budget_manager_records_usage():
     catalog = [{"id": "dummy", "pricing": {"prompt": 0.002, "completion": 0.003}}]
     manager = BudgetManager("dummy", token_limit=100, catalog=catalog)
 
-    manager.record_usage(50)
+    manager.record_llm_usage(50)
     expected_cost = 50 * (0.002 + 0.003) / 1000
 
     assert manager.tokens_used == 50


### PR DESCRIPTION
## Summary
- add enforce_limit and record_llm_usage helpers in `BudgetManager`
- use new helpers in `CacheManager` and `ConversationManager`
- update tests for changed API

## Testing
- `flake8 core/budget.py core/cache_manager.py core/conversation.py tests/test_budget_enforcement.py tests/test_budget.py`
- `pytest tests/test_budget_enforcement.py -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry.instrumentation.requests')*

------
https://chatgpt.com/codex/tasks/task_e_684c763bba3883338861f88ed86ee2eb