### PR TITLE
Introduce StrategyFactory

### DIFF
--- a/claude/cort-web-integration.py
+++ b/claude/cort-web-integration.py
@@ -21,7 +21,8 @@ from core.providers.cache import HybridCacheProvider, InMemoryLRUCache, DiskCach
 from core.providers.resilient_llm import ResilientLLMProvider
 from core.providers.embeddings import EmbeddingProvider
 from core.providers.quality import EnhancedQualityEvaluator
-from core.chat_v2 import RecursiveThinkingEngine, AdaptiveThinkingStrategy
+from core.chat_v2 import RecursiveThinkingEngine
+from core.strategies import StrategyFactory
 from core.context_manager import ContextManager
 from core.security.api_security import (
     APIKeyManager,
@@ -209,8 +210,9 @@ async def create_thinking_engine() -> RecursiveThinkingEngine:
     )
 
     # Create thinking strategy
-    strategy = AdaptiveThinkingStrategy(
-        resilient_llm,
+    factory = StrategyFactory(resilient_llm, evaluator)
+    strategy = factory.create(
+        config.thinking_strategy,
         max_rounds=config.performance.max_thinking_rounds,
         quality_threshold=config.performance.quality_threshold,
     )

--- a/config/config.py
+++ b/config/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
     embed_url: str = "https://openrouter.ai/api/v1/embeddings"
     frontend_url: str = "http://localhost:3000"
     ws_base_url: str = "ws://localhost:8000"
+    thinking_strategy: str = Field("adaptive", env="THINKING_STRATEGY")
 
     class Config:
         env_file = ".env"

--- a/core/strategies/__init__.py
+++ b/core/strategies/__init__.py
@@ -4,12 +4,13 @@ from .base import ThinkingStrategy
 from .adaptive import AdaptiveThinkingStrategy
 from .hybrid import HybridToolStrategy
 from .fixed import FixedThinkingStrategy
-from .factory import load_strategy
+from .factory import StrategyFactory, load_strategy
 
 __all__ = [
     "ThinkingStrategy",
     "AdaptiveThinkingStrategy",
     "FixedThinkingStrategy",
     "HybridToolStrategy",
+    "StrategyFactory",
     "load_strategy",
 ]

--- a/docs/STRATEGIES.md
+++ b/docs/STRATEGIES.md
@@ -4,6 +4,9 @@ The project supports multiple strategies for controlling the number of recursive
 thinking rounds. Strategies live in `core.strategies` and can be selected at
 runtime.
 
+Strategy creation is handled by `StrategyFactory`, which receives an LLM
+provider and quality evaluator when an engine is built.
+
 ## Available Strategies
 
 - **adaptive** – Uses the LLM to decide how many rounds are required and stops
@@ -12,9 +15,10 @@ runtime.
 
 ## Selecting a Strategy
 
-`CoRTConfig` has a `thinking_strategy` field which defaults to `"adaptive"`.
-When creating an engine using `create_default_engine`, the provided value is
-resolved by `core.strategies.load_strategy`.
+`CoRTConfig` has a `thinking_strategy` field which defaults to the value of the
+`THINKING_STRATEGY` environment variable (falling back to `"adaptive"`). When
+creating an engine using `create_default_engine`, the strategy is obtained from
+`StrategyFactory`.
 
 ```python
 from core import CoRTConfig, create_default_engine
@@ -24,3 +28,9 @@ engine = create_default_engine(config)
 ```
 
 Unknown strategy names fall back to the adaptive implementation.
+
+## Runtime configuration
+
+The active strategy can also be set via the `THINKING_STRATEGY` environment
+variable or the equivalent setting in a configuration file. The factory will use
+this value when no explicit strategy name is provided.


### PR DESCRIPTION
## Summary
- add `thinking_strategy` environment config
- create `StrategyFactory` class for constructing strategies
- build default engine using factory
- update web integration to fetch strategies from the factory
- document runtime strategy configuration

## Testing
- `flake8 config/config.py core/chat_v2.py core/strategies/factory.py core/strategies/__init__.py claude/cort-web-integration.py`
- `PYTHONPATH=$PWD pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684c763cd214833381907699a2211883