### PR TITLE
Implement plugin registry for strategies

### DIFF
--- a/core/strategies/__init__.py
+++ b/core/strategies/__init__.py
@@ -1,10 +1,50 @@
-"""Thinking strategy implementations and loader."""
+"""Thinking strategies and dynamic registry."""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+from typing import Dict, Type
 
 from .base import ThinkingStrategy
 from .adaptive import AdaptiveThinkingStrategy
 from .hybrid import HybridToolStrategy
 from .fixed import FixedThinkingStrategy
-from .factory import load_strategy
+
+_REGISTRY: Dict[str, Type[ThinkingStrategy]] = {}
+
+
+def register_strategy(name: str, cls: Type[ThinkingStrategy]) -> None:
+    """Register a strategy implementation."""
+    _REGISTRY[name.lower()] = cls
+
+
+def get_strategy(name: str) -> Type[ThinkingStrategy] | None:
+    """Retrieve a strategy class by name."""
+    return _REGISTRY.get(name.lower())
+
+
+def available_strategies() -> list[str]:
+    """Return names of all registered strategies."""
+    return sorted(_REGISTRY)
+
+
+def _load_entrypoints(group: str = "mils_strategies") -> None:
+    """Load strategy plugins from entry points."""
+    for ep in entry_points(group=group):
+        try:
+            cls = ep.load()
+            register_strategy(ep.name, cls)
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+
+register_strategy("adaptive", AdaptiveThinkingStrategy)
+register_strategy("fixed", FixedThinkingStrategy)
+register_strategy("hybrid", HybridToolStrategy)
+
+_load_entrypoints()
+
+from .factory import load_strategy  # noqa: E402
 
 __all__ = [
     "ThinkingStrategy",
@@ -12,4 +52,7 @@ __all__ = [
     "FixedThinkingStrategy",
     "HybridToolStrategy",
     "load_strategy",
+    "register_strategy",
+    "get_strategy",
+    "available_strategies",
 ]

--- a/core/strategies/factory.py
+++ b/core/strategies/factory.py
@@ -6,13 +6,7 @@ from .adaptive import AdaptiveThinkingStrategy
 from .fixed import FixedThinkingStrategy
 from .hybrid import HybridToolStrategy
 from .base import ThinkingStrategy
-
-
-_STRATEGY_MAP = {
-    "adaptive": AdaptiveThinkingStrategy,
-    "fixed": FixedThinkingStrategy,
-    "hybrid": HybridToolStrategy,
-}
+from . import get_strategy
 
 
 def load_strategy(
@@ -22,7 +16,7 @@ def load_strategy(
     **kwargs,
 ) -> ThinkingStrategy:
     """Load a thinking strategy by name with fallback to adaptive."""
-    cls = _STRATEGY_MAP.get(name.lower(), AdaptiveThinkingStrategy)
-    if cls is FixedThinkingStrategy:
+    cls = get_strategy(name) or AdaptiveThinkingStrategy
+    if issubclass(cls, FixedThinkingStrategy):
         return cls(**kwargs)
     return cls(llm, evaluator, **kwargs)

--- a/tests/test_strategy_plugins.py
+++ b/tests/test_strategy_plugins.py
@@ -1,0 +1,60 @@
+import importlib
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+pkg = ModuleType("core")
+pkg.__path__ = [os.path.abspath("core")]
+sys.modules["core"] = pkg
+
+dummy = ModuleType("core.chat_v2")
+dummy.ThinkingResult = object
+dummy.ThinkingRound = object
+sys.modules["core.chat_v2"] = dummy
+
+spec = importlib.util.spec_from_file_location(
+    "core.strategies", os.path.join("core", "strategies", "__init__.py")
+)
+strategies = importlib.util.module_from_spec(spec)
+sys.modules["core.strategies"] = strategies
+spec.loader.exec_module(strategies)
+
+
+class DummyLLM:
+    async def chat(self, *a, **k):
+        return SimpleNamespace(content="1")
+
+
+class DummyEval:
+    thresholds = {"overall": 0.9}
+
+    def score(self, resp: str, prompt: str) -> float:
+        return 0.0
+
+
+class DummyEP:
+    name = "dummy"
+
+    def load(self):
+        class DummyStrategy(strategies.FixedThinkingStrategy):
+            pass
+
+        return DummyStrategy
+
+
+def fake_entry_points(*, group=None):
+    if group == "mils_strategies":
+        return [DummyEP()]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_plugin_registry(monkeypatch):
+    monkeypatch.setattr("importlib.metadata.entry_points", fake_entry_points)
+    importlib.reload(strategies)
+    assert "dummy" in strategies.available_strategies()
+    strat = strategies.load_strategy("dummy", DummyLLM(), DummyEval())
+    assert strat.__class__.__name__ == "DummyStrategy"


### PR DESCRIPTION
## Summary
- add dynamic plugin registry in `core.strategies`
- load strategies from configurable entry point `mils_strategies`
- update factory to consult registry and handle FixedThinkingStrategy subclasses
- build default engine using registered strategies
- add tests for plugin discovery

## Testing
- `flake8 core/strategies/__init__.py tests/test_strategy_plugins.py core/strategies/factory.py core/chat_v2.py`
- `PYTHONPATH=. pytest tests/test_strategy_plugins.py -q`
- `PYTHONPATH=. pytest` *(fails: 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684c763fd5d083338e83da6adfd0674b