### PR TITLE
Add convergence limits and edge tests

### DIFF
--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -123,6 +123,7 @@ class RecursiveThinkingEngine:
         self.convergence_strategy = convergence_strategy or ConvergenceStrategy(
             evaluator.score,
             evaluator.score,
+            max_iterations=5,
             advanced=False,  # Will be passed explicitly in create_default_engine
         )
         self.model_selector = model_selector

--- a/core/recursion.py
+++ b/core/recursion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Callable, Dict, List, Tuple
 from statistics import mean, pstdev
 import re
+import time
 
 
 class TrendConvergenceStrategy:
@@ -184,11 +185,13 @@ class ConvergenceStrategy:
         similarity_fn: Callable[[str, str], float],
         score_fn: Callable[[str, str], float],
         *,
+        max_iterations: int,
         similarity_threshold: float = 0.95,
         improvement_threshold: float = 0.01,
         oscillation_threshold: float = 0.95,
         window: int = 3,
         history_size: int = 5,
+        time_limit: float | None = None,
         advanced: bool = False,
     ) -> None:
         strategy_cls = StatisticalConvergenceStrategy if advanced else TrendConvergenceStrategy
@@ -203,18 +206,42 @@ class ConvergenceStrategy:
             ),
             history_size=history_size,
         )
+        self.max_iterations = max_iterations
+        self.time_limit = time_limit
+        self.iterations = 0
+        self.start_time: float | None = None
 
     def add(self, response: str, prompt: str) -> None:
         """Add response to the history."""
+        if self.start_time is None:
+            self.start_time = time.time()
+        self.iterations += 1
         self._tracker.add(response, prompt)
 
     def update(self, response: str, prompt: str) -> Tuple[bool, str]:
         """Add and immediately check for convergence."""
-        return self._tracker.update(response, prompt)
+        self.add(response, prompt)
+        return self.should_continue(prompt)
 
     def should_continue(self, prompt: str) -> Tuple[bool, str]:
         """Evaluate whether processing should continue."""
-        return self._tracker.should_continue(prompt)
+        cont, reason = self._tracker.should_continue(prompt)
+        if not cont:
+            return cont, reason
+        if self.iterations >= self.max_iterations:
+            if self._tracker.reason_history:
+                self._tracker.reason_history[-1] = "max iterations"
+            else:
+                self._tracker.reason_history.append("max iterations")
+            return False, "max iterations"
+        if self.time_limit is not None and self.start_time is not None:
+            if time.time() - self.start_time >= self.time_limit:
+                if self._tracker.reason_history:
+                    self._tracker.reason_history[-1] = "time limit"
+                else:
+                    self._tracker.reason_history.append("time limit")
+                return False, "time limit"
+        return True, reason
 
     @property
     def rolling_average(self) -> float:

--- a/core/recursive_engine_v2.py
+++ b/core/recursive_engine_v2.py
@@ -70,6 +70,7 @@ class OptimizedRecursiveEngine:
         self.convergence_strategy = convergence_strategy or ConvergenceStrategy(
             lambda a, b: evaluator.score(a, b),
             evaluator.score,
+            max_iterations=5,
         )
 
         # Optimizers
@@ -404,6 +405,7 @@ def create_optimized_engine(config: CoRTConfig) -> OptimizedRecursiveEngine:
     convergence = ConvergenceStrategy(
         evaluator.score,
         evaluator.score,
+        max_iterations=5,
         advanced=config.advanced_convergence,
     )
 

--- a/tests/test_chat_v2.py
+++ b/tests/test_chat_v2.py
@@ -126,6 +126,7 @@ class TestRecursiveThinkingEngine:
         convergence = ConvergenceStrategy(
             lambda a, b: evaluator.score(a, b),
             evaluator.score,
+            max_iterations=3,
         )
 
         engine = RecursiveThinkingEngine(
@@ -352,6 +353,7 @@ class TestIntegration:
         convergence = ConvergenceStrategy(
             lambda a, b: evaluator.score(a, b),
             evaluator.score,
+            max_iterations=3,
         )
 
         engine = RecursiveThinkingEngine(
@@ -406,6 +408,7 @@ class TestIntegration:
         convergence = ConvergenceStrategy(
             lambda a, b: evaluator.score(a, b),
             evaluator.score,
+            max_iterations=2,
         )
 
         engine = RecursiveThinkingEngine(

--- a/tests/test_convergence_scoring.py
+++ b/tests/test_convergence_scoring.py
@@ -17,6 +17,7 @@ def test_convergence_detection():
     strat = ConvergenceStrategy(
         lambda a, b: 1.0 if a == b else 0.0,
         lambda r, p: len(r),
+        max_iterations=3,
     )
     strat.add("one", "p")
     strat.add("one", "p")
@@ -35,6 +36,7 @@ def test_rolling_average_and_plateau_detection():
     strat = ConvergenceStrategy(
         lambda a, b: 0.0,
         lambda r, p: float(r),
+        max_iterations=10,
         improvement_threshold=0.05,
         window=2,
     )

--- a/tests/test_memory_retrieval.py
+++ b/tests/test_memory_retrieval.py
@@ -102,7 +102,11 @@ async def test_memory_influences_response():
     context_manager = ContextManager(100, tokenizer)
     conversation = ConversationManager(llm, context_manager)
     strategy = MockThinkingStrategy()
-    convergence = ConvergenceStrategy(lambda a, b: 1.0, evaluator.score)
+    convergence = ConvergenceStrategy(
+        lambda a, b: 1.0,
+        evaluator.score,
+        max_iterations=2,
+    )
 
     engine = RecursiveThinkingEngine(
         llm=llm,

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -66,7 +66,11 @@ async def test_engine_stores_plans():
     tokenizer = type("Tok", (), {"encode": lambda self, t: t.split()})()
     context_manager = ContextManager(100, tokenizer)
     strategy = DummyStrategy()
-    convergence = ConvergenceStrategy(lambda a, b: 0.0, lambda r, p: 0.0)
+    convergence = ConvergenceStrategy(
+        lambda a, b: 0.0,
+        lambda r, p: 0.0,
+        max_iterations=2,
+    )
     planner = ImprovementPlanner(llm)
     engine = RecursiveThinkingEngine(
         llm=llm,

--- a/tests/test_statistical_convergence.py
+++ b/tests/test_statistical_convergence.py
@@ -15,6 +15,7 @@ def test_statistical_convergence_detection():
     strat = ConvergenceStrategy(
         lambda a, b: 0.0,
         lambda r, p: float(r),
+        max_iterations=10,
         window=3,
         improvement_threshold=0.0005,
         advanced=True,

--- a/tests/test_tool_integration.py
+++ b/tests/test_tool_integration.py
@@ -1,14 +1,17 @@
-import os, sys
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-import pytest
+import os
+import sys
 
-from core.tools import ToolRegistry, SearchTool, PythonExecutionTool
-from core.strategies import HybridToolStrategy
-from core.chat_v2 import RecursiveThinkingEngine
-from core.context_manager import ContextManager
-from core.recursion import ConvergenceStrategy
-from core.providers.cache import InMemoryLRUCache
-from core.interfaces import LLMProvider, QualityEvaluator
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest  # noqa: E402
+
+from core.tools import ToolRegistry, SearchTool, PythonExecutionTool  # noqa: E402
+from core.strategies import HybridToolStrategy  # noqa: E402
+from core.chat_v2 import RecursiveThinkingEngine  # noqa: E402
+from core.context_manager import ContextManager  # noqa: E402
+from core.recursion import ConvergenceStrategy  # noqa: E402
+from core.providers.cache import InMemoryLRUCache  # noqa: E402
+from core.interfaces import LLMProvider, QualityEvaluator  # noqa: E402
 
 
 class DummyLLM(LLMProvider):
@@ -52,9 +55,12 @@ async def test_hybrid_strategy_invokes_tools():
         context_manager=ContextManager(100, type("Tok", (), {"encode": lambda s, t: t.split()})()),
         tools=registry,
         thinking_strategy=strategy,
-        convergence_strategy=ConvergenceStrategy(lambda a, b: 0.0, lambda r, p: 0.0),
+        convergence_strategy=ConvergenceStrategy(
+            lambda a, b: 0.0,
+            lambda r, p: 0.0,
+            max_iterations=5,
+        ),
     )
 
     await engine.think_and_respond("search: cats")
     assert "cats info" in llm.last_messages[-1]["content"]
-


### PR DESCRIPTION
## Summary
- extend ConvergenceStrategy with max_iterations and time_limit support
- enforce convergence limits in LoopController
- propagate new parameter to engines
- test engine edge cases around convergence

## Testing
- `flake8 core/loop_controller.py core/recursion.py core/chat_v2.py core/recursive_engine_v2.py tests/test_chat_v2.py tests/test_recursive_engine_edges.py tests/test_tool_integration.py tests/test_convergence_scoring.py tests/test_memory_retrieval.py tests/test_planning.py tests/test_statistical_convergence.py`
- `pytest tests/test_recursive_engine_edges.py::test_loop_respects_max_iterations -q`
- `pytest tests/test_recursive_engine_edges.py::test_loop_respects_time_limit -q`

------
https://chatgpt.com/codex/tasks/task_e_684c76411a5883338b6c238b32ed42dd