### PR TITLE
Add loop state persistence

### DIFF
--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -158,6 +158,7 @@ class RecursiveThinkingEngine:
         thinking_rounds: Optional[int] = None,
         alternatives_per_round: int = 3,
         temperature: float = 0.7,
+        session_id: Optional[str] = None,
         metadata: Optional[Dict[str, object]] = None,
     ) -> ThinkingResult:
         """Execute the recursive loop via :class:`LoopController`."""
@@ -166,6 +167,7 @@ class RecursiveThinkingEngine:
             thinking_rounds=thinking_rounds,
             alternatives_per_round=alternatives_per_round,
             temperature=temperature,
+            session_id=session_id,
             metadata=metadata,
         )
         return result

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -133,6 +133,7 @@ class MetricsRecorder(Protocol):
         token_usage: int,
         num_rounds: int,
         convergence_reason: str,
+        quality_scores: list[float] | None = None,
         **kwargs
     ) -> None:
         """Record metrics for a thinking run."""

--- a/core/metrics_manager.py
+++ b/core/metrics_manager.py
@@ -20,6 +20,7 @@ class MetricsManager:
         token_usage: int,
         num_rounds: int,
         convergence_reason: str,
+        quality_scores: Optional[list[float]] = None,
     ) -> None:
         if self.recorder:
             self.recorder.record_run(
@@ -27,4 +28,5 @@ class MetricsManager:
                 token_usage=token_usage,
                 num_rounds=num_rounds,
                 convergence_reason=convergence_reason,
+                quality_scores=quality_scores or [],
             )

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -13,6 +13,7 @@ class RunMetrics:
     token_usage: int
     num_rounds: int
     convergence_reason: str
+    quality_scores: List[float] = field(default_factory=list)
     timestamp: datetime = field(default_factory=datetime.utcnow)
 
 
@@ -29,12 +30,14 @@ class MetricsRecorder:
         token_usage: int,
         num_rounds: int,
         convergence_reason: str,
+        quality_scores: List[float] | None = None,
     ) -> None:
         run = RunMetrics(
             processing_time=processing_time,
             token_usage=token_usage,
             num_rounds=num_rounds,
             convergence_reason=convergence_reason,
+            quality_scores=quality_scores or [],
         )
         self.runs.append(run)
         self.logger.info("run_metrics", **asdict(run))

--- a/recthink_web_v2.py
+++ b/recthink_web_v2.py
@@ -75,6 +75,7 @@ async def chat_endpoint(request: ChatRequest):
             request.message,
             thinking_rounds=request.thinking_rounds,
             alternatives_per_round=request.alternatives_per_round,
+            session_id=request.session_id,
         )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -128,6 +129,7 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
                     message,
                     thinking_rounds=rounds,
                     alternatives_per_round=alts,
+                    session_id=session_id,
                 )
             except Exception as exc:
                 await websocket.send_json({"error": str(exc)})

--- a/tests/test_api_customization.py
+++ b/tests/test_api_customization.py
@@ -18,6 +18,7 @@ class DummyEngine:
         message,
         thinking_rounds=None,
         alternatives_per_round=3,
+        session_id=None,
     ):
         self.captured["rounds"] = thinking_rounds
         self.captured["alts"] = alternatives_per_round

--- a/tests/test_loop_state.py
+++ b/tests/test_loop_state.py
@@ -1,0 +1,93 @@
+import os
+import sys
+from unittest.mock import MagicMock
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+mock_instr = types.ModuleType("opentelemetry.instrumentation.aiohttp_client")
+mock_instr.AioHttpClientInstrumentor = type(
+    "AioHttpClientInstrumentor",
+    (),
+    {"instrument": lambda *a, **k: None, "uninstrument": lambda *a, **k: None},
+)
+sys.modules.setdefault("opentelemetry.instrumentation.aiohttp_client", mock_instr)
+mock_req = types.ModuleType("opentelemetry.instrumentation.requests")
+mock_req.RequestsInstrumentor = type(
+    "RequestsInstrumentor",
+    (),
+    {"instrument": lambda *a, **k: None, "uninstrument": lambda *a, **k: None},
+)
+sys.modules.setdefault("opentelemetry.instrumentation.requests", mock_req)
+
+import pytest  # noqa: E402
+
+from core.chat_v2 import RecursiveThinkingEngine  # noqa: E402
+from core.context_manager import ContextManager  # noqa: E402
+from core.recursion import ConvergenceStrategy  # noqa: E402
+from core.providers.cache import InMemoryLRUCache  # noqa: E402
+from core.loop_controller import LoopState  # noqa: E402
+
+
+class DummyLLM:
+    async def chat(self, messages, *, temperature=0.7, **kwargs):
+        return type(
+            "Resp",
+            (),
+            {
+                "content": "reply",
+                "usage": {"total_tokens": 1},
+                "model": "dummy",
+                "cached": False,
+            },
+        )()
+
+
+class DummyEvaluator:
+    thresholds = {"overall": 0.5}
+
+    def score(self, response: str, prompt: str) -> float:
+        return 0.6
+
+
+class SimpleStrategy:
+    async def determine_rounds(self, prompt: str) -> int:
+        return 1
+
+    async def should_continue(self, rounds_completed, quality_scores, responses):
+        return False, "complete"
+
+
+@pytest.mark.asyncio
+async def test_loop_state_persistence(tmp_path, monkeypatch):
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda text: text.split()
+    context_manager = ContextManager(50, tokenizer)
+
+    engine = RecursiveThinkingEngine(
+        llm=DummyLLM(),
+        cache=InMemoryLRUCache(),
+        evaluator=DummyEvaluator(),
+        context_manager=context_manager,
+        thinking_strategy=SimpleStrategy(),
+        convergence_strategy=ConvergenceStrategy(
+            lambda a, b: 0.0,
+            DummyEvaluator().score,
+        ),
+        model_selector=None,
+    )
+
+    async def _score(response, prompt):
+        return engine.evaluator.score(response, prompt)
+
+    engine._score_response = _score
+
+    monkeypatch.setattr("core.loop_controller.SESSION_DIR", str(tmp_path))
+
+    await engine.think_and_respond("Hi", session_id="sess1")
+
+    history = await engine.loop_controller.load_loop_history("sess1")
+    assert len(history) == 1
+    assert isinstance(history[0], LoopState)
+    reasons = await engine.loop_controller.get_convergence_reasons("sess1")
+    assert reasons == ["complete"]

--- a/tests/test_recthink_web_v2.py
+++ b/tests/test_recthink_web_v2.py
@@ -9,7 +9,13 @@ from core.chat_v2 import ThinkingResult, ThinkingRound  # noqa: E402
 
 
 class DummyEngine:
-    async def think_and_respond(self, message, thinking_rounds=None, alternatives_per_round=3):
+    async def think_and_respond(
+        self,
+        message,
+        thinking_rounds=None,
+        alternatives_per_round=3,
+        session_id=None,
+    ):
         return ThinkingResult(
             response="ok",
             thinking_rounds=1,


### PR DESCRIPTION
## Summary
- track reasoning loop state with `LoopState`
- persist reasoning history and load past runs
- expose convergence reasons and session-level storage
- record quality scores in metrics
- pass session ids through API and tests
- test loop state persistence

## Testing
- `flake8 core/chat_v2.py core/interfaces.py core/loop_controller.py core/metrics_manager.py monitoring/metrics.py recthink_web_v2.py tests/test_api_customization.py tests/test_recthink_web_v2.py tests/test_loop_state.py`
- `pytest tests/test_loop_state.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684c76424c9c8333a54dee3b4a1be7f5