### PR TITLE
Add request ID logging utility

### DIFF
--- a/core/cache_manager.py
+++ b/core/cache_manager.py
@@ -38,13 +38,18 @@ class CacheManager:
         *,
         temperature: float,
         role: str,
+        metadata: Optional[Dict[str, object]] = None,
     ) -> LLMResponse:
         """Return cached response or call the LLM."""
 
         key = self._generate_key(messages, temperature)
         cached = await self.cache.get(key)
         if cached:
-            logger.info("cache_hit", key=key[:8])
+            logger.info(
+                "cache_hit",
+                key=key[:8],
+                request_id=(metadata or {}).get("request_id"),
+            )
             if hasattr(cached, "cached"):
                 cached.cached = True
             return cached
@@ -52,7 +57,11 @@ class CacheManager:
         if self.model_selector:
             self.llm.model = self.model_selector.model_for_role(role)
 
-        response = await self.llm.chat(messages, temperature=temperature)
+        response = await self.llm.chat(
+            messages,
+            temperature=temperature,
+            metadata=metadata,
+        )
 
         if self.budget_manager:
             tokens = response.usage.get("total_tokens", 0)

--- a/core/planning.py
+++ b/core/planning.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from core.interfaces import LLMProvider
+from monitoring.telemetry import generate_request_id
 
 
 @dataclass
@@ -25,5 +26,9 @@ class ImprovementPlanner:
                 "content": f"Prompt: {prompt}\nResponse: {current_response}",
             },
         ]
-        result = await self.llm.chat(messages, temperature=0.2)
+        result = await self.llm.chat(
+            messages,
+            temperature=0.2,
+            metadata={"request_id": generate_request_id()},
+        )
         return result.content.strip()

--- a/core/providers/resilient_llm.py
+++ b/core/providers/resilient_llm.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 import structlog
 
 from core.providers.llm import LLMProvider, LLMResponse
+from monitoring.telemetry import generate_request_id
 from core.resilience.circuit_breaker import CircuitBreaker, CircuitOpenError
 from core.resilience.retry_policies import (
     ExponentialBackoffPolicy,
@@ -143,8 +144,10 @@ class ResilientLLMProvider:
             APIError: If all providers fail
         """
         start_time = time.time()
+        metadata = metadata or {}
         self._request_count += 1
-        request_id = f"req_{self._request_count}"
+        request_id = metadata.get("request_id") or generate_request_id()
+        metadata["request_id"] = request_id
         
         logger.info(
             "resilient_llm_request",

--- a/core/strategies/adaptive.py
+++ b/core/strategies/adaptive.py
@@ -35,7 +35,7 @@ class AdaptiveThinkingStrategy(ThinkingStrategy):
         )
         self.improvement_threshold = improvement_threshold
 
-    async def determine_rounds(self, prompt: str) -> int:
+    async def determine_rounds(self, prompt: str, *, request_id: str) -> int:
         """Use the LLM to determine optimal number of rounds."""
         meta_prompt = (
             f"Analyze this prompt and determine the optimal number of thinking rounds"
@@ -45,15 +45,21 @@ class AdaptiveThinkingStrategy(ThinkingStrategy):
             f"Respond with just a number between {self.min_rounds} "
             f"and {self.max_rounds}."
         )
-        response = await self.llm.chat([
-            {"role": "user", "content": meta_prompt}
-        ], temperature=0.3)
+        response = await self.llm.chat(
+            [{"role": "user", "content": meta_prompt}],
+            temperature=0.3,
+            metadata={"request_id": request_id},
+        )
 
         try:
             rounds = int("".join(filter(str.isdigit, response.content)))
             return max(self.min_rounds, min(rounds, self.max_rounds))
         except (ValueError, TypeError):
-            logger.warning("Failed to parse thinking rounds", response=response.content)
+            logger.warning(
+                "Failed to parse thinking rounds",
+                response=response.content,
+                request_id=request_id,
+            )
             return 3
 
     async def should_continue(
@@ -61,6 +67,8 @@ class AdaptiveThinkingStrategy(ThinkingStrategy):
         rounds_completed: int,
         quality_scores: List[float],
         responses: List[str],
+        *,
+        request_id: str,
     ) -> tuple[bool, str]:
         """Determine if thinking should continue."""
         if rounds_completed >= self.max_rounds:

--- a/core/strategies/base.py
+++ b/core/strategies/base.py
@@ -6,7 +6,7 @@ from typing import List, Protocol
 class ThinkingStrategy(Protocol):
     """Protocol defining the thinking strategy interface."""
 
-    async def determine_rounds(self, prompt: str) -> int:
+    async def determine_rounds(self, prompt: str, *, request_id: str) -> int:
         """Determine number of thinking rounds needed."""
 
     async def should_continue(
@@ -14,5 +14,7 @@ class ThinkingStrategy(Protocol):
         rounds_completed: int,
         quality_scores: List[float],
         responses: List[str],
+        *,
+        request_id: str,
     ) -> tuple[bool, str]:
         """Return whether to continue and the reason."""

--- a/core/strategies/hybrid.py
+++ b/core/strategies/hybrid.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 import structlog
 
 from core.interfaces import LLMProvider, QualityEvaluator
@@ -40,4 +38,3 @@ class HybridToolStrategy(AdaptiveThinkingStrategy):
             result = await engine.run_tool("python", code)
             prompt += f"\nPython output:\n{result}"
         return prompt
-

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -12,3 +12,19 @@ Grafana can be used to visualize these metrics with the provided dashboard.
 
 The dashboard displays request latency, convergence details and other
 metrics from `metrics_v2.py`.
+
+## Tracing Requests
+
+Every call to the thinking engine is tagged with a short `request_id`.
+This ID appears in all logs produced by the controller, providers and
+strategies. To trace a request across components, search your logs for the
+generated ID:
+
+```json
+{"event": "loop_start", "request_id": "a1b2c3d4", "prompt": "..."}
+...
+{"event": "llm_request_success", "request_id": "a1b2c3d4"}
+```
+
+Use this identifier to correlate metrics and log messages for a single
+session or API call.

--- a/monitoring/telemetry.py
+++ b/monitoring/telemetry.py
@@ -6,6 +6,8 @@ import asyncio
 import functools
 from contextlib import asynccontextmanager, contextmanager
 from typing import Any, Callable, Dict, Optional, TypeVar
+import uuid
+import logging
 
 from opentelemetry import trace, metrics
 from opentelemetry.exporter.prometheus import PrometheusMetricReader
@@ -32,6 +34,26 @@ T = TypeVar('T')
 _tracer: Optional[trace.Tracer] = None
 _meter: Optional[metrics.Meter] = None
 _metrics: Optional['CoRTMetrics'] = None
+
+
+def generate_request_id() -> str:
+    """Generate a short request/session identifier."""
+    return uuid.uuid4().hex[:8]
+
+
+def configure_logging(level: str = "INFO", fmt: str = "json") -> None:
+    """Configure structlog for JSON or console output."""
+    processors = [
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+    ]
+    if fmt == "json":
+        processors.append(structlog.processors.JSONRenderer())
+    else:
+        processors.append(structlog.dev.ConsoleRenderer())
+
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+    structlog.configure(processors=processors)
 
 
 class CoRTMetrics:
@@ -158,6 +180,8 @@ def initialize_telemetry(
     enable_prometheus: bool = True,
     prometheus_port: int = 8080,
     jaeger_endpoint: Optional[str] = None,
+    log_level: str = "INFO",
+    log_format: str = "json",
 ) -> None:
     """
     Initialize OpenTelemetry with configured exporters.
@@ -171,6 +195,8 @@ def initialize_telemetry(
         jaeger_endpoint: Jaeger collector endpoint
     """
     global _tracer, _meter, _metrics
+
+    configure_logging(log_level, log_format)
     
     # Create resource
     resource = Resource.create({


### PR DESCRIPTION
## Summary
- add `generate_request_id` and logging helpers
- include request_id in controller, provider and strategy logs
- document tracing example in monitoring guide

## Testing
- `flake8 core/planning.py core/cache_manager.py core/providers/critic.py core/providers/llm.py core/providers/resilient_llm.py core/strategies/adaptive.py core/strategies/base.py core/strategies/hybrid.py monitoring/telemetry.py core/loop_controller.py`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c7643ac208333bdb59a7bc78c2459