### PR TITLE
Add tracing integration and health endpoint

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -12,3 +12,10 @@ Grafana can be used to visualize these metrics with the provided dashboard.
 
 The dashboard displays request latency, convergence details and other
 metrics from `metrics_v2.py`.
+
+## Enabling Tracing
+
+Tracing is initialized in `recthink_web_v2.py` using functions from
+`monitoring/telemetry.py`. Call `initialize_telemetry` and then
+`instrument_fastapi(app)` to attach tracing middleware. Ensure the
+`opentelemetry-instrumentation-fastapi` package is installed.

--- a/monitoring/telemetry.py
+++ b/monitoring/telemetry.py
@@ -11,6 +11,8 @@ from opentelemetry import trace, metrics
 from opentelemetry.exporter.prometheus import PrometheusMetricReader
 from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from fastapi import FastAPI
 from opentelemetry.metrics import Histogram, Counter, UpDownCounter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.resources import Resource
@@ -444,3 +446,12 @@ def record_provider_failure(provider: str, error_type: str) -> None:
     """Record a provider failure."""
     metrics = get_metrics()
     metrics.provider_failures.add(1, {"provider": provider, "error_type": error_type})
+
+
+def instrument_fastapi(app: "FastAPI", *, excluded_urls: str = "/docs,/openapi.json") -> None:
+    """Attach OpenTelemetry tracing middleware to a FastAPI app."""
+    FastAPIInstrumentor().instrument_app(
+        app,
+        tracer_provider=trace.get_tracer_provider(),
+        excluded_urls=excluded_urls,
+    )

--- a/recthink_web_v2.py
+++ b/recthink_web_v2.py
@@ -17,7 +17,7 @@ from core.recursive_engine_v2 import (
     create_optimized_engine,
 )
 from monitoring.metrics_v2 import MetricsAnalyzer, ThinkingMetrics
-from monitoring.telemetry import initialize_telemetry
+from monitoring.telemetry import initialize_telemetry, instrument_fastapi
 from config.config import load_production_config
 
 app = FastAPI(title="RecThink API v2")
@@ -54,6 +54,7 @@ async def init_telemetry() -> None:
         prometheus_port=cfg.monitoring.prometheus_port,
         jaeger_endpoint=cfg.monitoring.jaeger_endpoint,
     )
+    instrument_fastapi(app)
 
 
 class ChatRequest(BaseModel):
@@ -153,6 +154,12 @@ async def provider_health() -> Dict[str, List[Dict[str, object]]]:
     health = metrics_analyzer.get_provider_health()
     logger.info("provider_health_status", providers=health)
     return {"providers": health}
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    """Basic health check for service availability."""
+    return {"status": "ok"}
 
 
 @app.websocket("/ws/stream/{session_id}")


### PR DESCRIPTION
## Summary
- expose FastAPI tracing middleware in `telemetry` module
- instrument `recthink_web_v2` with tracing and add `/health` endpoint
- document tracing setup in monitoring guide

## Testing
- `flake8 monitoring/telemetry.py recthink_web_v2.py`
- `pytest tests/test_monitoring.py -k test_initialize_telemetry -q` *(fails: ModuleNotFoundError: No module named 'monitoring')*

------
https://chatgpt.com/codex/tasks/task_e_684c7644bd70833385220bac22f67db8