### PR TITLE
Implement output filtering

### DIFF
--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -38,6 +38,7 @@ from core.tools import ToolRegistry, SearchTool, PythonExecutionTool  # noqa: F4
 from core.memory import FaissMemoryStore
 from api import fetch_models  # noqa: F401
 from config import settings
+from core.security import OutputFilter
 import tiktoken  # noqa: F401
 
 
@@ -114,6 +115,7 @@ class RecursiveThinkingEngine:
         tools: Optional[ToolRegistry] = None,
         planner: Optional["ImprovementPlanner"] = None,
         memory_store: Optional["FaissMemoryStore"] = None,
+        output_filter: Optional["OutputFilter"] = None,
     ) -> None:
         self.llm = llm
         self.cache = cache
@@ -143,6 +145,7 @@ class RecursiveThinkingEngine:
         self.planner = planner
         self.memory_store = memory_store
         self.loop_controller = LoopController(self)
+        self.output_filter = output_filter
 
         if hasattr(self.thinking_strategy, "set_tools"):
             self.thinking_strategy.set_tools(self.tools)
@@ -168,6 +171,8 @@ class RecursiveThinkingEngine:
             temperature=temperature,
             metadata=metadata,
         )
+        if self.output_filter:
+            result.response = self.output_filter.filter(result.response)
         return result
 
 

--- a/core/security/__init__.py
+++ b/core/security/__init__.py
@@ -11,6 +11,7 @@ from .api_security import (
     ValidationError,
     RateLimitError,
 )
+from .output_filter import OutputFilter
 
 __all__ = [
     "APIKeyManager",
@@ -22,4 +23,5 @@ __all__ = [
     "SecurityError",
     "ValidationError",
     "RateLimitError",
+    "OutputFilter",
 ]

--- a/core/security/output_filter.py
+++ b/core/security/output_filter.py
@@ -1,0 +1,31 @@
+"""Utilities for sanitizing LLM outputs."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+
+class OutputFilter:
+    """Filter text based on blocked patterns and PII masking."""
+
+    def __init__(self, blocked_patterns: Iterable[str] | None = None, mask_pii: bool = True) -> None:
+        self.patterns: List[re.Pattern[str]] = [re.compile(p) for p in blocked_patterns or []]
+        self.mask_pii = mask_pii
+
+        self.api_key_re = re.compile(r"[A-Za-z0-9]{32,}")
+        self.email_re = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+        self.phone_re = re.compile(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b")
+
+    def filter(self, text: str) -> str:
+        """Validate and optionally sanitize ``text``."""
+        for pattern in self.patterns:
+            if pattern.search(text):
+                raise ValueError("Response contains blocked content")
+
+        if self.mask_pii:
+            text = self.api_key_re.sub("[REDACTED]", text)
+            text = self.email_re.sub("[EMAIL]", text)
+            text = self.phone_re.sub("[PHONE]", text)
+
+        return text


### PR DESCRIPTION
## Summary
- add `OutputFilter` for pattern blocking and PII masking
- expose the filter in the security package
- integrate optional filter in `RecursiveThinkingEngine`
- test output filtering behaviour

## Testing
- `flake8 core/security/output_filter.py core/security/__init__.py core/chat_v2.py tests/test_security.py`
- `pytest -q` *(fails: ModuleNotFoundError for `tenacity` and others)*

------
https://chatgpt.com/codex/tasks/task_e_684c764533108333b0433d35c9e29508