### PR TITLE
Add mocks and unit tests

### DIFF
--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, AsyncIterator
+
+from core.interfaces import LLMProvider, CacheProvider, QualityEvaluator
+
+
+@dataclass
+class MockLLMResponse:
+    content: str
+    usage: Dict[str, int]
+    model: str
+    cached: bool = False
+
+
+class MockLLMProvider(LLMProvider):
+    """Simple LLM provider returning predefined responses."""
+
+    def __init__(self, responses: Optional[List[str]] = None) -> None:
+        self.responses = responses or ["ok"]
+        self.call_count = 0
+        self.model = "mock"
+
+    async def chat(
+        self,
+        messages: List[Dict[str, str]],
+        *,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        metadata: Optional[Dict] = None,
+    ) -> MockLLMResponse:
+        response = self.responses[min(self.call_count, len(self.responses) - 1)]
+        self.call_count += 1
+        tokens = len(response.split())
+        return MockLLMResponse(
+            content=response,
+            usage={"total_tokens": tokens},
+            model=self.model,
+            cached=False,
+        )
+
+    async def stream_chat(
+        self,
+        messages: List[Dict[str, str]],
+        *,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+    ) -> AsyncIterator[str]:
+        response = self.responses[min(self.call_count, len(self.responses) - 1)]
+        self.call_count += 1
+        for chunk in response.split():
+            yield chunk
+
+
+class MockCacheProvider(CacheProvider):
+    """In-memory cache provider for testing."""
+
+    def __init__(self) -> None:
+        self.store: Dict[str, Any] = {}
+
+    async def get(self, key: str) -> Optional[Any]:
+        return self.store.get(key)
+
+    async def set(
+        self,
+        key: str,
+        value: Any,
+        *,
+        ttl: Optional[int] = None,
+        tags: Optional[List[str]] = None,
+    ) -> None:
+        self.store[key] = value
+
+    async def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+    async def clear(self, *, tag: Optional[str] = None) -> int:
+        count = len(self.store)
+        self.store.clear()
+        return count
+
+    async def stats(self) -> Dict[str, Any]:
+        return {"size": len(self.store)}
+
+
+class MockQualityEvaluator(QualityEvaluator):
+    """Quality evaluator returning preset scores."""
+
+    def __init__(self, scores: Optional[Dict[str, float]] = None, thresholds: Optional[Dict[str, float]] = None) -> None:
+        self.scores = scores or {}
+        self.thresholds = thresholds or {"overall": 0.9}
+
+    def score(self, response: str, prompt: str) -> float:
+        return self.scores.get(response, 0.5)
+
+    def detailed_score(self, response: str, prompt: str) -> Dict[str, float]:
+        return {"overall": self.score(response, prompt)}

--- a/tests/test_budget_manager_mock.py
+++ b/tests/test_budget_manager_mock.py
@@ -1,0 +1,39 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import pytest  # noqa: E402
+from core.budget import BudgetManager  # noqa: E402
+from exceptions import TokenLimitError  # noqa: E402
+from core.cache_manager import CacheManager  # noqa: E402
+from tests.mocks import MockLLMProvider, MockCacheProvider  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_budget_manager_limits(monkeypatch):
+    llm = MockLLMProvider(["too many tokens"])
+    cache = MockCacheProvider()
+    budget = BudgetManager("m", token_limit=2, catalog=[{"id": "m", "pricing": {}}])
+    manager = CacheManager(llm, cache, budget_manager=budget)
+
+    monkeypatch.setattr("core.cache_manager.logger", type("L", (), {"info": lambda *a, **k: None})())
+
+    with pytest.raises(TokenLimitError):
+        await manager.chat([{"role": "user", "content": "hi"}], temperature=0.7, role="assistant")
+
+    assert budget.tokens_used == 0
+
+
+@pytest.mark.asyncio
+async def test_budget_manager_records(monkeypatch):
+    llm = MockLLMProvider(["ok"])
+    cache = MockCacheProvider()
+    budget = BudgetManager("m", token_limit=10, catalog=[{"id": "m", "pricing": {}}])
+    manager = CacheManager(llm, cache, budget_manager=budget)
+
+    monkeypatch.setattr("core.cache_manager.logger", type("L", (), {"info": lambda *a, **k: None})())
+
+    resp = await manager.chat([{"role": "user", "content": "hi"}], temperature=0.7, role="assistant")
+
+    assert budget.tokens_used == resp.usage["total_tokens"]
+    assert budget.dollars_spent == 0.0

--- a/tests/test_loop_controller.py
+++ b/tests/test_loop_controller.py
@@ -1,0 +1,80 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import types
+fake = types.ModuleType("core.chat_v2")
+
+class ThinkingResult:
+    pass
+
+class ThinkingRound:
+    pass
+
+class CoRTConfig:
+    pass
+
+fake.ThinkingResult = ThinkingResult
+fake.ThinkingRound = ThinkingRound
+fake.CoRTConfig = CoRTConfig
+sys.modules.setdefault("core.chat_v2", fake)
+import pytest  # noqa: E402
+from core.loop_controller import LoopController  # noqa: E402
+from tests.mocks import MockLLMProvider, MockCacheProvider, MockQualityEvaluator  # noqa: E402
+
+
+class DummyEngine:
+    def __init__(self, cached_response: str | None = None) -> None:
+        self.llm = MockLLMProvider(["initial"])
+        self.cache = MockCacheProvider()
+        self.evaluator = MockQualityEvaluator({"initial": 0.8})
+        self.prompt_history: list[str] = []
+        self.enable_compression = False
+        self.enable_adaptive = False
+        self.adaptive_optimizer = None
+        self.parallel_optimizer = None
+        self.cached_response = cached_response
+
+    async def _check_semantic_cache(self, prompt: str):
+        return self.cached_response
+
+    async def _compress_prompt(self, prompt: str, context):
+        return prompt
+
+    async def _generate_initial(self, prompt: str, context):
+        return await self.llm.chat([{"role": "user", "content": prompt}])
+
+    async def _score_response(self, response: str, prompt: str) -> float:
+        return self.evaluator.score(response, prompt)
+
+    async def _update_semantic_cache(self, prompt: str, response: str, quality: float):
+        self.updated = (prompt, response, quality)
+
+    def _categorize_prompt(self, prompt: str) -> str:
+        return "general"
+
+
+@pytest.mark.asyncio
+async def test_run_loop_cache_hit(monkeypatch):
+    engine = DummyEngine(cached_response="cached")
+    controller = LoopController(engine)
+    monkeypatch.setattr("core.loop_controller.record_thinking_metrics", lambda *a, **k: None)
+
+    result = await controller.run_loop("hello")
+
+    assert result["cached"] is True
+    assert result["response"] == "cached"
+
+
+@pytest.mark.asyncio
+async def test_run_loop_basic(monkeypatch):
+    engine = DummyEngine()
+    controller = LoopController(engine)
+    monkeypatch.setattr("core.loop_controller.record_thinking_metrics", lambda *a, **k: None)
+
+    result = await controller.run_loop("hello")
+
+    assert result["cached"] is False
+    assert result["response"] == "initial"
+    assert engine.updated[0] == "hello"
+    assert engine.prompt_history == ["hello"]

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -1,0 +1,25 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import pytest  # noqa: E402
+from core.cache_manager import CacheManager  # noqa: E402
+from core.model_policy import ModelSelector  # noqa: E402
+from tests.mocks import MockLLMProvider, MockCacheProvider  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_cache_manager_routes_and_caches(monkeypatch):
+    llm = MockLLMProvider(["first"])
+    cache = MockCacheProvider()
+    selector = ModelSelector([{"id": "a"}, {"id": "b"}], {"assistant": "b"})
+    manager = CacheManager(llm, cache, model_selector=selector)
+
+    monkeypatch.setattr("core.cache_manager.logger", type("L", (), {"info": lambda *a, **k: None})())
+
+    messages = [{"role": "user", "content": "hi"}]
+    resp1 = await manager.chat(messages, temperature=0.7, role="assistant")
+    assert llm.model == "b"
+    resp2 = await manager.chat(messages, temperature=0.7, role="assistant")
+    assert resp2.cached
+    assert resp1.content == resp2.content


### PR DESCRIPTION
## Summary
- add mock classes for the common provider interfaces
- add unit tests for LoopController, CacheManager model routing and BudgetManager

## Testing
- `flake8 tests/mocks/__init__.py tests/test_loop_controller.py tests/test_model_router.py tests/test_budget_manager_mock.py`
- `pytest tests/test_loop_controller.py tests/test_model_router.py tests/test_budget_manager_mock.py -q` *(fails: cannot import name 'RecursiveThinkingEngine')*

------
https://chatgpt.com/codex/tasks/task_e_684c7647705083338c89414feb4bca88