### PR TITLE
Update strategy docs and architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ config = CoRTConfig(
 engine = create_optimized_engine(config)
 ```
 
+### Thinking strategies
+
+Select how the engine decides when to stop thinking by setting
+`CoRTConfig.thinking_strategy`. The name is resolved by
+`core.strategies.load_strategy` at engine creation time.
+
+```python
+from core import CoRTConfig, create_default_engine
+
+config = CoRTConfig(thinking_strategy="hybrid")
+engine = create_default_engine(config)
+```
+
 * `docs/EXTENDING.md#custom-providers`
 * `docs/EXTENDING.md#custom-strategies`
 * `docs/STRATEGIES.md` for runtime strategy selection

--- a/docs/ARCHITECTURE_AUDIT.md
+++ b/docs/ARCHITECTURE_AUDIT.md
@@ -6,6 +6,26 @@ The repository implements an interesting recursive thinking architecture, but su
 
 The current API is served by `recthink_web_v2.py` and offers `/chat` and WebSocket endpoints for streaming updates. Providers include both OpenRouter and OpenAI implementations with a resilient wrapper. Recent additions introduce a `ModelSelector` for policy-based role models and a `BudgetManager` that enforces token caps while tracking costs in real time.
 
+## Component Overview
+
+### LoopController
+The `LoopController` orchestrates the core recursive loop. It calls the engine's
+LLM provider, evaluator and caching layers while applying the selected thinking
+strategy. Running both blocking and streaming modes, it is responsible for
+recording metrics and capturing intermediate thinking rounds.
+
+### ModelRouter
+`ModelRouter` builds on the `ModelSelector` concept by routing prompts to the
+appropriate provider and model for each role. This enables heterogeneous model
+setups where critics or planners use different models than the main assistant.
+Routing decisions are policy based and transparent to the engine.
+
+### BudgetManager
+The `BudgetManager` tracks token usage and computes cost statistics for each
+session. It exposes methods for checking if an action would exceed the budget
+and increments spend after every provider call. This ensures prompts remain
+within predefined limits while giving real-time feedback on spending.
+
 ## Critical Issues & Solutions
 
 ### 1. Architectural Problems

--- a/docs/STRATEGIES.md
+++ b/docs/STRATEGIES.md
@@ -19,8 +19,30 @@ resolved by `core.strategies.load_strategy`.
 ```python
 from core import CoRTConfig, create_default_engine
 
-config = CoRTConfig(thinking_strategy="fixed")
+config = CoRTConfig(
+    thinking_strategy="fixed",
+    quality_thresholds={"overall": 0.8},
+)
 engine = create_default_engine(config)
 ```
 
 Unknown strategy names fall back to the adaptive implementation.
+
+## Advanced configuration
+
+`load_strategy` can be used directly when you need to pass custom parameters or
+register your own implementation.
+
+```python
+from core.strategies import load_strategy
+from core.chat_v2 import RecursiveThinkingEngine
+
+strategy = load_strategy("fixed", llm, evaluator, rounds=2)
+engine = RecursiveThinkingEngine(
+    llm=llm,
+    cache=cache,
+    evaluator=evaluator,
+    context_manager=context,
+    thinking_strategy=strategy,
+)
+```


### PR DESCRIPTION
## Summary
- describe new LoopController, ModelRouter and BudgetManager in the architecture audit
- document strategy loader usage and config example
- mention thinking strategy selection in README

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_684c764ce60083338dd077d0d44d8e98