### PR TITLE
Refactor engine setup for external router and budget manager

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -6,6 +6,7 @@ from .chat_v2 import (
     RecursiveThinkingEngine,
     create_default_engine,
 )
+from .model_router import ModelRouter
 from .strategies import AdaptiveThinkingStrategy, load_strategy
 from .recursive_engine_v2 import create_optimized_engine
 from .recursion import ConvergenceStrategy, StatisticalConvergenceStrategy
@@ -23,4 +24,5 @@ __all__ = [
     "StatisticalConvergenceStrategy",
     "AdaptiveThinkingAgent",
     "ImprovementPlanner",
+    "ModelRouter",
 ]

--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -29,6 +29,7 @@ from core.providers import (  # noqa: F401
 )
 from core.planning import ImprovementPlanner
 from core.model_policy import ModelSelector
+from core.model_router import ModelRouter
 from core.budget import BudgetManager
 from core.cache_manager import CacheManager
 from core.metrics_manager import MetricsManager
@@ -107,6 +108,7 @@ class RecursiveThinkingEngine:
         thinking_strategy: ThinkingStrategy,
         convergence_strategy: Optional[ConvergenceStrategy] = None,
         model_selector: Optional[ModelSelector] = None,
+        model_router: Optional[ModelRouter] = None,
         *,
         cache_manager: Optional[CacheManager] = None,
         metrics_manager: Optional[MetricsManager] = None,
@@ -130,6 +132,7 @@ class RecursiveThinkingEngine:
             advanced=False,  # Will be passed explicitly in create_default_engine
         )
         self.model_selector = model_selector
+        self.model_router = model_router
         self.budget_manager = budget_manager
         self.cache_manager = cache_manager or CacheManager(
             llm,
@@ -183,59 +186,35 @@ class RecursiveThinkingEngine:
         return result
 
 
-def create_default_engine(config: CoRTConfig) -> RecursiveThinkingEngine:
+def create_default_engine(
+    config: CoRTConfig,
+    *,
+    router: Optional[ModelRouter] = None,
+    budget_manager: Optional[BudgetManager] = None,
+) -> RecursiveThinkingEngine:
     """Build a :class:`RecursiveThinkingEngine` from configuration."""
 
-    if config.provider.lower() == "openai":
-        llm = OpenAILLMProvider(
-            api_key=config.api_key or os.getenv("OPENAI_API_KEY"),
-            model=config.model,
-            max_retries=config.max_retries,
-        )
-    else:
-        llm = OpenRouterLLMProvider(
-            api_key=config.api_key or os.getenv("OPENROUTER_API_KEY"),
-            model=config.model,
-            max_retries=config.max_retries,
-        )
+    selector: Optional[ModelSelector] = None
+    if config.model_policy:
+        metadata = fetch_models()
+        selector = ModelSelector(metadata, config.model_policy)
 
-    cache = InMemoryLRUCache(max_size=config.cache_size)
-    evaluator = EnhancedQualityEvaluator(thresholds=config.quality_thresholds)
-
-    """Build a :class:`RecursiveThinkingEngine` using :class:`StrategyFactory`."""
-
-    if config.provider.lower() == "openai":
-        llm = OpenAILLMProvider(
-            api_key=config.api_key or os.getenv("OPENAI_API_KEY"),
-            model=config.model,
-            max_retries=config.max_retries,
-        )
-    else:
-        llm = OpenRouterLLMProvider(
-            api_key=config.api_key or os.getenv("OPENROUTER_API_KEY"),
-            model=config.model,
-            max_retries=config.max_retries,
-        )
+    router = router or ModelRouter.from_config(config, selector)
+    llm = router.provider_for_role("assistant")
 
     cache = InMemoryLRUCache(max_size=config.cache_size)
     evaluator = EnhancedQualityEvaluator(thresholds=config.quality_thresholds)
 
     tokenizer = tiktoken.get_encoding("cl100k_base")
-    context_manager = ContextManager(config.max_context_tokens, tokenizer)
+    ctx_mgr = ContextManager(config.max_context_tokens, tokenizer)
 
-    factory = StrategyFactory(llm, evaluator)
-    strategy = factory.create(config.thinking_strategy)
-
+    strategy = load_strategy(config.thinking_strategy, llm, evaluator)
     convergence = ConvergenceStrategy(
         evaluator.score,
         evaluator.score,
         advanced=config.advanced_convergence,
     )
 
-    tokenizer = tiktoken.get_encoding("cl100k_base")
-    ctx_mgr = ContextManager(config.max_context_tokens, tokenizer)
-
-    strategy = load_strategy(config.thinking_strategy, llm, evaluator)
     tools = ToolRegistry()
     if config.enable_tools:
         tools.register(SearchTool())
@@ -248,8 +227,7 @@ def create_default_engine(config: CoRTConfig) -> RecursiveThinkingEngine:
         context_manager=ctx_mgr,
         thinking_strategy=strategy,
         convergence_strategy=convergence,
-        context_manager=context_manager,
-        thinking_strategy=strategy,
-        convergence_strategy=convergence,
+        model_router=router,
+        budget_manager=budget_manager,
         tools=tools,
     )

--- a/core/recursive_engine_v2.py
+++ b/core/recursive_engine_v2.py
@@ -17,6 +17,7 @@ from core.interfaces import (
 from core.chat_v2 import CoRTConfig
 from core.model_policy import ModelSelector
 from core.model_router import ModelRouter
+from core.budget import BudgetManager
 from api import fetch_models
 from core.providers import (
     InMemoryLRUCache,
@@ -54,11 +55,12 @@ class OptimizedRecursiveEngine:
 
     def __init__(
         self,
-        llm: Optional[LLMProvider],
+        llm: LLMProvider,
         cache: CacheProvider,
         evaluator: QualityEvaluator,
         *,
         model_router: Optional[ModelRouter] = None,
+        budget_manager: Optional[BudgetManager] = None,
         critic: Optional[CriticLLM] = None,
         enable_parallel: bool = True,
         enable_adaptive: bool = True,
@@ -66,15 +68,9 @@ class OptimizedRecursiveEngine:
         max_cache_size: int = 10000,
         convergence_strategy: Optional[ConvergenceStrategy] = None,
     ):
-        if model_router and llm is None:
-            llm = model_router.provider_for_role("assistant")
-            if critic is None:
-                try:
-                    critic = CriticLLM(model_router.provider_for_role("critic"))
-                except Exception:  # pragma: no cover - optional critic
-                    critic = None
 
         self.model_router = model_router
+        self.budget_manager = budget_manager
         self.llm = llm  # type: ignore[assignment]
         self.cache = cache
         self.evaluator = evaluator
@@ -370,45 +366,28 @@ Rules:
         return stats
 
 
-def create_optimized_engine(config: CoRTConfig) -> OptimizedRecursiveEngine:
+def create_optimized_engine(
+    config: CoRTConfig,
+    *,
+    router: Optional[ModelRouter] = None,
+    budget_manager: Optional[BudgetManager] = None,
+) -> OptimizedRecursiveEngine:
     """Build an :class:`OptimizedRecursiveEngine` from configuration."""
 
     selector: Optional[ModelSelector] = None
     if config.model_policy:
         metadata = fetch_models()
         selector = ModelSelector(metadata, config.model_policy)
-        default_model = selector.model_for_role("assistant")
 
-    if config.provider.lower() == "openai":
-        llm = OpenAILLMProvider(
-            api_key=config.api_key or credential_manager.get("OPENAI_API_KEY"),
-            model=default_model,
-            max_retries=config.max_retries,
-        )
-    else:
-        llm = OpenRouterLLMProvider(
-            api_key=config.api_key or credential_manager.get("OPENROUTER_API_KEY"),
-            model=default_model,
-            max_retries=config.max_retries,
-        )
+    router = router or ModelRouter.from_config(config, selector)
+    llm = router.provider_for_role("assistant")
 
     critic = None
-    if selector:
-        critic_model = selector.model_for_role("critic")
-        if config.provider.lower() == "openai":
-            critic_provider = OpenAILLMProvider(
-                api_key=config.api_key or credential_manager.get("OPENAI_API_KEY"),
-                model=critic_model,
-                max_retries=config.max_retries,
-            )
-        else:
-            critic_provider = OpenRouterLLMProvider(
-                api_key=config.api_key or credential_manager.get("OPENROUTER_API_KEY"),
-                model=critic_model,
-                max_retries=config.max_retries,
-            )
+    try:
+        critic_provider = router.provider_for_role("critic")
         critic = CriticLLM(critic_provider)
-
+    except Exception:
+        critic = None
 
     cache = InMemoryLRUCache(max_size=config.cache_size)
     evaluator = EnhancedQualityEvaluator(thresholds=config.quality_thresholds)
@@ -420,10 +399,12 @@ def create_optimized_engine(config: CoRTConfig) -> OptimizedRecursiveEngine:
     )
 
     return OptimizedRecursiveEngine(
-        llm=None,
+        llm=llm,
         cache=cache,
         evaluator=evaluator,
         model_router=router,
+        budget_manager=budget_manager,
+        critic=critic,
         convergence_strategy=convergence,
         enable_parallel=config.enable_parallel_thinking,
     )

--- a/tests/test_api_customization.py
+++ b/tests/test_api_customization.py
@@ -38,7 +38,7 @@ def test_send_message_custom_rounds(monkeypatch):
     monkeypatch.setattr(
         recthink_web_v2,
         "create_optimized_engine",
-        lambda config: engine,
+        lambda config, router=None, budget_manager=None: engine,
     )
 
     client = TestClient(recthink_web_v2.app)
@@ -63,7 +63,7 @@ def test_send_message_defaults(monkeypatch):
     monkeypatch.setattr(
         recthink_web_v2,
         "create_optimized_engine",
-        lambda config: engine,
+        lambda config, router=None, budget_manager=None: engine,
     )
 
     client = TestClient(recthink_web_v2.app)

--- a/tests/test_recthink_web_v2.py
+++ b/tests/test_recthink_web_v2.py
@@ -47,7 +47,11 @@ def setup_module(module):
 
 def test_chat_endpoint(monkeypatch):
     client = TestClient(recthink_web_v2.app)
-    monkeypatch.setattr(recthink_web_v2, "create_optimized_engine", lambda config: DummyEngine())
+    monkeypatch.setattr(
+        recthink_web_v2,
+        "create_optimized_engine",
+        lambda config, router=None, budget_manager=None: DummyEngine(),
+    )
 
     resp = client.post("/chat", json={"session_id": "s1", "message": "hi"})
     assert resp.status_code == 200
@@ -59,7 +63,11 @@ def test_chat_endpoint(monkeypatch):
 
 def test_websocket_endpoint(monkeypatch):
     client = TestClient(recthink_web_v2.app)
-    monkeypatch.setattr(recthink_web_v2, "create_optimized_engine", lambda config: DummyEngine())
+    monkeypatch.setattr(
+        recthink_web_v2,
+        "create_optimized_engine",
+        lambda config, router=None, budget_manager=None: DummyEngine(),
+    )
 
     with client.websocket_connect("/ws/s2") as ws:
         ws.send_text(json.dumps({"message": "hello"}))
@@ -70,7 +78,11 @@ def test_websocket_endpoint(monkeypatch):
 
 def test_websocket_stream(monkeypatch):
     client = TestClient(recthink_web_v2.app)
-    monkeypatch.setattr(recthink_web_v2, "create_optimized_engine", lambda config: DummyEngine())
+    monkeypatch.setattr(
+        recthink_web_v2,
+        "create_optimized_engine",
+        lambda config, router=None, budget_manager=None: DummyEngine(),
+    )
 
     with client.websocket_connect("/ws/stream/s3") as ws:
         ws.send_text(json.dumps({"message": "hi"}))
@@ -86,7 +98,7 @@ def test_websocket_stream_order(monkeypatch):
     monkeypatch.setattr(
         recthink_web_v2,
         "create_optimized_engine",
-        lambda config: DummyEngine(),
+        lambda config, router=None, budget_manager=None: DummyEngine(),
     )
 
     with client.websocket_connect("/ws/stream/s4") as ws:
@@ -130,7 +142,7 @@ def test_batch_chat_endpoint(monkeypatch):
     monkeypatch.setattr(
         recthink_web_v2,
         "create_optimized_engine",
-        lambda config: EngineWithParallel(),
+        lambda config, router=None, budget_manager=None: EngineWithParallel(),
     )
 
     class DummyAnalyzer:

--- a/tests/test_statistical_convergence.py
+++ b/tests/test_statistical_convergence.py
@@ -9,6 +9,8 @@ from core.recursion import (  # noqa: E402
     StatisticalConvergenceStrategy,
 )
 from core.chat_v2 import CoRTConfig, create_default_engine  # noqa: E402
+from core.model_router import ModelRouter  # noqa: E402
+from core.budget import BudgetManager  # noqa: E402
 
 
 def test_statistical_convergence_detection():
@@ -32,7 +34,9 @@ def test_statistical_convergence_detection():
 
 def test_engine_advanced_switch():
     cfg = CoRTConfig(advanced_convergence=True)
-    engine = create_default_engine(cfg)
+    router = ModelRouter.from_config(cfg)
+    budget = BudgetManager(cfg.model, token_limit=cfg.budget_token_limit, catalog=[{"id": cfg.model, "pricing": {}}])
+    engine = create_default_engine(cfg, router=router, budget_manager=budget)
     assert isinstance(
         engine.convergence_strategy._tracker.strategy,
         StatisticalConvergenceStrategy,


### PR DESCRIPTION
## Summary
- finalize provider selection in `ModelRouter`
- export `ModelRouter` from package
- let engines accept injected `ModelRouter` and `BudgetManager`
- adapt engine factory helpers accordingly
- update affected tests

## Testing
- `flake8 core/__init__.py core/chat_v2.py core/model_router.py core/recursive_engine_v2.py tests/test_api_customization.py tests/test_parallel_thinking.py tests/test_recthink_web_v2.py tests/test_statistical_convergence.py tests/test_strategies.py`
- `pytest -q` *(fails: SyntaxError in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_684c834abbcc8333a3ec329cf8d23319