### PR TITLE
Implement strategy factory for engine configuration

### DIFF
--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -10,7 +10,7 @@ import os  # noqa: F401
 
 import structlog
 
-from .strategies import AdaptiveThinkingStrategy  # noqa: F401
+from core.strategies import ThinkingStrategy, strategy_from_config
 from core.interfaces import (
     CacheProvider,
     LLMProvider,
@@ -18,7 +18,6 @@ from core.interfaces import (
 )
 from core.context_manager import ContextManager
 from core.recursion import ConvergenceStrategy
-from core.strategies import StrategyFactory, ThinkingStrategy, load_strategy  # noqa: F401
 from monitoring.metrics import MetricsRecorder
 from core.providers import (  # noqa: F401
     OpenRouterLLMProvider,
@@ -202,29 +201,10 @@ def create_default_engine(config: CoRTConfig) -> RecursiveThinkingEngine:
     cache = InMemoryLRUCache(max_size=config.cache_size)
     evaluator = EnhancedQualityEvaluator(thresholds=config.quality_thresholds)
 
-    """Build a :class:`RecursiveThinkingEngine` using :class:`StrategyFactory`."""
-
-    if config.provider.lower() == "openai":
-        llm = OpenAILLMProvider(
-            api_key=config.api_key or os.getenv("OPENAI_API_KEY"),
-            model=config.model,
-            max_retries=config.max_retries,
-        )
-    else:
-        llm = OpenRouterLLMProvider(
-            api_key=config.api_key or os.getenv("OPENROUTER_API_KEY"),
-            model=config.model,
-            max_retries=config.max_retries,
-        )
-
-    cache = InMemoryLRUCache(max_size=config.cache_size)
-    evaluator = EnhancedQualityEvaluator(thresholds=config.quality_thresholds)
-
     tokenizer = tiktoken.get_encoding("cl100k_base")
     context_manager = ContextManager(config.max_context_tokens, tokenizer)
 
-    factory = StrategyFactory(llm, evaluator)
-    strategy = factory.create(config.thinking_strategy)
+    strategy = strategy_from_config(config, llm, evaluator)
 
     convergence = ConvergenceStrategy(
         evaluator.score,
@@ -232,10 +212,6 @@ def create_default_engine(config: CoRTConfig) -> RecursiveThinkingEngine:
         advanced=config.advanced_convergence,
     )
 
-    tokenizer = tiktoken.get_encoding("cl100k_base")
-    ctx_mgr = ContextManager(config.max_context_tokens, tokenizer)
-
-    strategy = load_strategy(config.thinking_strategy, llm, evaluator)
     tools = ToolRegistry()
     if config.enable_tools:
         tools.register(SearchTool())
@@ -245,9 +221,6 @@ def create_default_engine(config: CoRTConfig) -> RecursiveThinkingEngine:
         llm=llm,
         cache=cache,
         evaluator=evaluator,
-        context_manager=ctx_mgr,
-        thinking_strategy=strategy,
-        convergence_strategy=convergence,
         context_manager=context_manager,
         thinking_strategy=strategy,
         convergence_strategy=convergence,

--- a/core/strategies/__init__.py
+++ b/core/strategies/__init__.py
@@ -45,9 +45,7 @@ register_strategy("hybrid", HybridToolStrategy)
 
 _load_entrypoints()
 
-from .factory import load_strategy  # noqa: E402
-
-from .factory import StrategyFactory, load_strategy
+from .factory import StrategyFactory, load_strategy, strategy_from_config  # noqa: E402
 
 
 __all__ = [
@@ -57,6 +55,7 @@ __all__ = [
     "HybridToolStrategy",
     "StrategyFactory",
     "load_strategy",
+    "strategy_from_config",
     "register_strategy",
     "get_strategy",
     "available_strategies",

--- a/core/strategies/factory.py
+++ b/core/strategies/factory.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from core.interfaces import LLMProvider
 from .base import ThinkingStrategy, QualityEvaluator
 
 from .adaptive import AdaptiveThinkingStrategy
 from .fixed import FixedThinkingStrategy
-from .hybrid import HybridToolStrategy
-from .base import ThinkingStrategy
-from . import get_strategy
+from . import get_strategy, register_strategy
 
-
-
-_STRATEGY_MAP = {
-    "adaptive": AdaptiveThinkingStrategy,
-    "fixed": FixedThinkingStrategy,
-    "hybrid": HybridToolStrategy,
-}
-
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    from core.chat_v2 import CoRTConfig
 
 
 class StrategyFactory:
@@ -25,18 +19,21 @@ class StrategyFactory:
     def __init__(self, llm: LLMProvider, evaluator: QualityEvaluator) -> None:
         self.llm = llm
         self.evaluator = evaluator
-        self._registry = dict(_STRATEGY_MAP)
 
     def register(self, name: str, cls: type[ThinkingStrategy]) -> None:
-        """Register a new strategy class."""
-        self._registry[name.lower()] = cls
+        """Register a new strategy class globally."""
+        register_strategy(name, cls)
 
     def create(self, name: str, **kwargs) -> ThinkingStrategy:
         """Instantiate a strategy by name."""
-        cls = self._registry.get(name.lower(), AdaptiveThinkingStrategy)
-        if cls is FixedThinkingStrategy:
+        cls = get_strategy(name) or AdaptiveThinkingStrategy
+        if issubclass(cls, FixedThinkingStrategy):
             return cls(**kwargs)
         return cls(self.llm, self.evaluator, **kwargs)
+
+    def from_config(self, config: "CoRTConfig", **kwargs) -> ThinkingStrategy:
+        """Create a strategy from a :class:`CoRTConfig` object."""
+        return self.create(config.thinking_strategy, **kwargs)
 
 
 def load_strategy(
@@ -45,13 +42,19 @@ def load_strategy(
     evaluator: QualityEvaluator,
     **kwargs,
 ) -> ThinkingStrategy:
-
     """Load a thinking strategy by name with fallback to adaptive."""
+
     cls = get_strategy(name) or AdaptiveThinkingStrategy
     if issubclass(cls, FixedThinkingStrategy):
         return cls(**kwargs)
     return cls(llm, evaluator, **kwargs)
 
-    """Compatibility wrapper around :class:`StrategyFactory`."""
-    return StrategyFactory(llm, evaluator).create(name, **kwargs)
 
+def strategy_from_config(
+    config: "CoRTConfig",
+    llm: LLMProvider,
+    evaluator: QualityEvaluator,
+    **kwargs,
+) -> ThinkingStrategy:
+    """Convenience wrapper to create a strategy from configuration."""
+    return load_strategy(config.thinking_strategy, llm, evaluator, **kwargs)


### PR DESCRIPTION
## Summary
- add `strategy_from_config` helper and clean `StrategyFactory`
- register builtin strategies and expose new factory API
- build default and optimized engines using the new strategy factory

## Testing
- `flake8 core/chat_v2.py core/recursive_engine_v2.py core/strategies/factory.py core/strategies/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_684c834add408333bbbb37b32b14205a