### PR TITLE
Implement output filter with PII masking

### DIFF
--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -190,9 +190,9 @@ def create_default_engine(
     *,
     router: Optional[ModelRouter] = None,
     budget_manager: Optional[BudgetManager] = None,
+    output_filter: Optional[OutputFilter] = None,
 ) -> RecursiveThinkingEngine:
     """Build a :class:`RecursiveThinkingEngine` from configuration."""
-
 
     if config.provider.lower() == "openai":
         llm = OpenAILLMProvider(
@@ -214,11 +214,6 @@ def create_default_engine(
     ctx_mgr = ContextManager(config.max_context_tokens, tokenizer)
 
     strategy = strategy_from_config(config, llm, evaluator)
-    strategy = StrategyFactory(llm, evaluator).create(config.thinking_strategy)
-
-
-
-    strategy = load_strategy(config.thinking_strategy, llm, evaluator)
     convergence = ConvergenceStrategy(
         evaluator.score,
         evaluator.score,
@@ -234,11 +229,11 @@ def create_default_engine(
         llm=llm,
         cache=cache,
         evaluator=evaluator,
-        context_manager=context_manager,
-        thinking_strategy=strategy,
-        convergence_strategy=convergence,
-        tools=tools,
         context_manager=ctx_mgr,
         thinking_strategy=strategy,
         convergence_strategy=convergence,
+        model_router=router,
+        budget_manager=budget_manager,
+        tools=tools,
+        output_filter=output_filter,
     )

--- a/core/security/output_filter.py
+++ b/core/security/output_filter.py
@@ -16,6 +16,8 @@ class OutputFilter:
         self.api_key_re = re.compile(r"[A-Za-z0-9]{32,}")
         self.email_re = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
         self.phone_re = re.compile(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b")
+        self.ssn_re = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+        self.credit_card_re = re.compile(r"\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b")
 
     def filter(self, text: str) -> str:
         """Validate and optionally sanitize ``text``."""
@@ -27,5 +29,7 @@ class OutputFilter:
             text = self.api_key_re.sub("[REDACTED]", text)
             text = self.email_re.sub("[EMAIL]", text)
             text = self.phone_re.sub("[PHONE]", text)
+            text = self.ssn_re.sub("[SSN]", text)
+            text = self.credit_card_re.sub("[CARD]", text)
 
         return text


### PR DESCRIPTION
## Summary
- implement `OutputFilter` with regex patterns for common PII
- apply `OutputFilter` to results in `RecursiveThinkingEngine`
- allow default engine creation to accept an output filter

## Testing
- `flake8 core/security/output_filter.py core/chat_v2.py`
- `pytest tests/test_security.py -k test_filter_blocks_pattern -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684c876b465083339e0a574223ce00e8