### PR TITLE
Add entry point strategy plugins

### DIFF
--- a/docs/STRATEGIES.md
+++ b/docs/STRATEGIES.md
@@ -58,3 +58,22 @@ The active strategy can also be set via the `THINKING_STRATEGY` environment
 variable or the equivalent setting in a configuration file. The factory will use
 this value when no explicit strategy name is provided.
 
+## Plugins
+
+Third-party packages can register new strategies via the `mils_strategies`
+entry point group. Each entry point should resolve to a
+`ThinkingStrategy` subclass:
+
+```toml
+[project.entry-points.mils_strategies]
+my_strategy = "mypkg.strategies:MyStrategy"
+```
+
+After installation the strategy becomes selectable just like built-in ones:
+
+```python
+from core.strategies import load_strategy
+
+strategy = load_strategy("my_strategy", llm, evaluator)
+```
+

--- a/tests/mocks/strategy_plugin.py
+++ b/tests/mocks/strategy_plugin.py
@@ -1,0 +1,6 @@
+from core.strategies.fixed import FixedThinkingStrategy
+
+class PluginStrategy(FixedThinkingStrategy):
+    """Simple strategy used for entry point plugin tests."""
+
+

--- a/tests/test_strategy_plugins.py
+++ b/tests/test_strategy_plugins.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import sys
 from types import ModuleType, SimpleNamespace
+from importlib.metadata import EntryPoint
 
 import pytest
 
@@ -35,19 +36,11 @@ class DummyEval:
         return 0.0
 
 
-class DummyEP:
-    name = "dummy"
-
-    def load(self):
-        class DummyStrategy(strategies.FixedThinkingStrategy):
-            pass
-
-        return DummyStrategy
-
-
 def fake_entry_points(*, group=None):
     if group == "mils_strategies":
-        return [DummyEP()]
+        path = os.path.join(os.path.dirname(__file__), "mocks")
+        sys.path.insert(0, path)
+        return [EntryPoint("dummy", "strategy_plugin:PluginStrategy", group)]
     return []
 
 
@@ -57,4 +50,4 @@ async def test_plugin_registry(monkeypatch):
     importlib.reload(strategies)
     assert "dummy" in strategies.available_strategies()
     strat = strategies.load_strategy("dummy", DummyLLM(), DummyEval())
-    assert strat.__class__.__name__ == "DummyStrategy"
+    assert strat.__class__.__name__ == "PluginStrategy"


### PR DESCRIPTION
## Summary
- load strategies from `mils_strategies` entry points
- document plugin usage
- add plugin example used in tests
- test strategy plugin discovery

## Testing
- `flake8 core/strategies/__init__.py tests/test_strategy_plugins.py tests/mocks/strategy_plugin.py`
- `pytest -q` *(fails: 31 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c87575f1c8333ba9fa2911c7da22d