### PR TITLE
Add session history retrieval

### DIFF
--- a/recthink_web_v2.py
+++ b/recthink_web_v2.py
@@ -16,6 +16,7 @@ from core.recursive_engine_v2 import (
     OptimizedRecursiveEngine,
     create_optimized_engine,
 )
+from core.loop_controller import LoopController
 from core.optimization.parallel_thinking import BatchThinkingOptimizer
 from monitoring.metrics_v2 import MetricsAnalyzer, ThinkingMetrics
 from monitoring.telemetry import initialize_telemetry, instrument_fastapi
@@ -197,6 +198,25 @@ async def provider_health() -> Dict[str, List[Dict[str, object]]]:
 async def health() -> Dict[str, str]:
     """Basic health check for service availability."""
     return {"status": "ok"}
+
+
+@app.get("/sessions/{session_id}/history")
+async def session_history(session_id: str) -> Dict[str, object]:
+    """Return persisted loop history for a session."""
+    controller = LoopController(None)
+    history = await controller.load_loop_history(session_id)
+    return {
+        "session_id": session_id,
+        "history": [asdict(h) for h in history],
+    }
+
+
+@app.get("/sessions/{session_id}/convergence")
+async def session_convergence(session_id: str) -> Dict[str, object]:
+    """Return convergence reasons for a session."""
+    controller = LoopController(None)
+    reasons = await controller.get_convergence_reasons(session_id)
+    return {"session_id": session_id, "reasons": reasons}
 
 
 @app.websocket("/ws/stream/{session_id}")


### PR DESCRIPTION
## Summary
- CLI accepts a session ID and exposes a `history` command
- API provides `/sessions/{session_id}/history` and `/sessions/{session_id}/convergence` endpoints
- tests cover new history endpoints

## Testing
- `flake8 cli/main.py recthink_web_v2.py tests/test_recthink_web_v2.py`
- `pytest -q` *(fails: SyntaxError and ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684c87638c088333baa6e3f1fbcbb728