### PR TITLE
Add encrypted secret loading and audit logging

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -200,6 +200,17 @@ class MonitoringSettings(BaseSettings):
         case_sensitive = False
 
 
+class RetentionSettings(BaseSettings):
+    """Data retention policies."""
+
+    log_retention_days: int = Field(30, env="LOG_RETENTION_DAYS")
+    audit_log_retention_days: int = Field(90, env="AUDIT_LOG_RETENTION_DAYS")
+    metrics_retention_days: int = Field(180, env="METRICS_RETENTION_DAYS")
+
+    class Config:
+        case_sensitive = False
+
+
 class PerformanceSettings(BaseSettings):
     """Performance tuning settings."""
 
@@ -258,6 +269,7 @@ class ProductionSettings(BaseSettings):
     memory: MemorySettings = Field(default_factory=MemorySettings)
     monitoring: MonitoringSettings = Field(default_factory=MonitoringSettings)
     performance: PerformanceSettings = Field(default_factory=PerformanceSettings)
+    retention: RetentionSettings = Field(default_factory=RetentionSettings)
 
     @field_validator("environment")
     @classmethod
@@ -297,6 +309,11 @@ def load_production_config() -> ProductionSettings:
                 "session_secret_key": os.getenv("SESSION_SECRET_KEY"),
             },
             "database": {"postgres_url": os.getenv("DATABASE_URL")},
+            "retention": {
+                "log_retention_days": os.getenv("LOG_RETENTION_DAYS"),
+                "audit_log_retention_days": os.getenv("AUDIT_LOG_RETENTION_DAYS"),
+                "metrics_retention_days": os.getenv("METRICS_RETENTION_DAYS"),
+            },
         }
         config = ProductionSettings.model_validate(data)
         _validate_runtime_config(config)

--- a/monitoring/telemetry.py
+++ b/monitoring/telemetry.py
@@ -29,6 +29,7 @@ from prometheus_client import start_http_server
 import structlog
 
 logger = structlog.get_logger(__name__)
+audit_logger = structlog.get_logger("audit")
 
 T = TypeVar('T')
 
@@ -56,6 +57,11 @@ def configure_logging(level: str = "INFO", fmt: str = "json") -> None:
 
     logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
     structlog.configure(processors=processors)
+
+
+def audit_log(event: str, **kwargs: Any) -> None:
+    """Record an audit log event."""
+    audit_logger.info(event, **kwargs)
 
 
 class CoRTMetrics:

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -1,0 +1,40 @@
+import json
+
+import pytest
+
+from cryptography.fernet import Fernet
+
+from core.security.credential_manager import CredentialManager
+from monitoring.telemetry import configure_logging
+
+
+@pytest.fixture
+def temp_secrets_file(tmp_path):
+    key = Fernet.generate_key()
+    data = {"TEST_SECRET": "value"}
+    cipher = Fernet(key)
+    encrypted = cipher.encrypt(json.dumps(data).encode())
+    file_path = tmp_path / "secrets.json"
+    file_path.write_bytes(encrypted)
+    return file_path, key.decode()
+
+
+def test_load_encrypted_secrets(temp_secrets_file, monkeypatch):
+    file_path, key = temp_secrets_file
+    monkeypatch.setenv("SECRETS_FILE", str(file_path))
+    monkeypatch.setenv("SECRETS_KEY", key)
+    manager = CredentialManager()
+    assert manager.get("TEST_SECRET") == "value"
+
+
+def test_audit_log_capture(temp_secrets_file, monkeypatch, caplog):
+    file_path, key = temp_secrets_file
+    monkeypatch.setenv("SECRETS_FILE", str(file_path))
+    monkeypatch.setenv("SECRETS_KEY", key)
+    configure_logging(fmt="json")
+    caplog.set_level("INFO")
+    manager = CredentialManager()
+    manager.get("TEST_SECRET")
+    events = [record.message for record in caplog.records]
+    assert any("secrets_file_loaded" in e for e in events)
+    assert any("credential_retrieved" in e for e in events)


### PR DESCRIPTION
## Summary
- load encrypted `secrets.json` automatically in `CredentialManager`
- record audit events through new `audit_log` utility
- include retention policy settings in configuration
- test credential manager encrypted loading and audit logging

## Testing
- `flake8 core/security/credential_manager.py monitoring/telemetry.py config/config.py tests/test_credential_manager.py`
- `pytest -q` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684c876c125883339f51d3bf4fcce8ab