### PR TITLE
Implement budget limit logging

### DIFF
--- a/core/budget.py
+++ b/core/budget.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
+import structlog
+
+
+logger = structlog.get_logger(__name__)
+
 from api import fetch_models
 
 
@@ -47,6 +52,12 @@ class BudgetManager:
         from exceptions import TokenLimitError
 
         if self.will_exceed_budget(next_tokens):
+            logger.warning(
+                "token_limit_exceeded",
+                used=self.tokens_used,
+                attempted=next_tokens,
+                limit=self.token_limit,
+            )
             raise TokenLimitError("Token budget exceeded")
 
     def record_llm_usage(self, tokens: int) -> None:

--- a/tests/test_budget_enforcement.py
+++ b/tests/test_budget_enforcement.py
@@ -4,6 +4,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 import pytest  # noqa: E402
 from core.budget import BudgetManager  # noqa: E402
 from exceptions import TokenLimitError  # noqa: E402
+from core.cache_manager import CacheManager  # noqa: E402
+from core.conversation import ConversationManager  # noqa: E402
+from core.context_manager import ContextManager  # noqa: E402
+from tests.mocks import MockLLMProvider, MockCacheProvider  # noqa: E402
 
 
 def test_budget_manager_loads_catalog(monkeypatch):
@@ -42,3 +46,47 @@ def test_enforce_limit(monkeypatch):
     assert manager.dollars_spent == pytest.approx(0.04)
     with pytest.raises(TokenLimitError):
         manager.enforce_limit(2)
+
+
+@pytest.mark.asyncio
+async def test_cache_manager_logs_on_limit(monkeypatch):
+    llm = MockLLMProvider(["too many tokens"])
+    cache = MockCacheProvider()
+    budget = BudgetManager("m", token_limit=2, catalog=[{"id": "m", "pricing": {}}])
+    manager = CacheManager(llm, cache, budget_manager=budget)
+
+    logs = []
+    monkeypatch.setattr(
+        "core.cache_manager.logger",
+        type("L", (), {"info": lambda *a, **k: None})(),
+    )
+    monkeypatch.setattr(
+        "core.budget.logger",
+        type("L", (), {"warning": lambda *a, **k: logs.append(k)})(),
+    )
+
+    with pytest.raises(TokenLimitError):
+        await manager.chat([{"role": "user", "content": "hi"}], temperature=0.7, role="assistant")
+
+    assert logs
+
+
+@pytest.mark.asyncio
+async def test_conversation_manager_logs_on_limit(monkeypatch):
+    llm = MockLLMProvider(["one two three"])
+    tokenizer = type("Tok", (), {"encode": lambda self, t: t.split()})()
+    context = ContextManager(100, tokenizer)
+    budget = BudgetManager("m", token_limit=2, catalog=[{"id": "m", "pricing": {}}])
+    convo = ConversationManager(llm, context, budget_manager=budget)
+    convo.add("user", "hello")
+
+    logs = []
+    monkeypatch.setattr(
+        "core.budget.logger",
+        type("L", (), {"warning": lambda *a, **k: logs.append(k)})(),
+    )
+
+    with pytest.raises(TokenLimitError):
+        await convo.summarize()
+
+    assert logs


### PR DESCRIPTION
## Summary
- log token limit violations in `BudgetManager.enforce_limit`
- test budget logging in cache and conversation managers

## Testing
- `flake8 core/budget.py tests/test_budget_enforcement.py`
- `pytest -q` *(fails: SyntaxError in chat_v2.py)*

------
https://chatgpt.com/codex/tasks/task_e_684c8c6abb58833396eb975cfd1cf890