### PR TITLE
Add structured logging to telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ This enables:
 3. Run server
    `uvicorn recthink_web_v2:app --reload`
 
+4. Enable structured logging (optional)
+   ```python
+   from monitoring.telemetry import configure_logging
+   configure_logging(level="INFO", fmt="json")
+   ```
+
 For CLI mode, frontend setup, and advanced options, see `docs/USAGE.md`.
 
 ## 🔑 Secret Storage

--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -172,6 +172,8 @@ class RecursiveThinkingEngine:
         metadata: Optional[Dict[str, object]] = None,
     ) -> ThinkingResult:
         """Execute the recursive loop via :class:`LoopController`."""
+        metadata = metadata or {}
+        metadata.setdefault("request_id", generate_request_id())
         result = await self.loop_controller.respond(
             prompt,
             thinking_rounds=thinking_rounds,

--- a/core/loop_controller.py
+++ b/core/loop_controller.py
@@ -227,10 +227,18 @@ class LoopController:
         }
 
     async def run_stream(
-        self, prompt: str, *, context: Optional[List[Dict[str, str]]] = None
+        self,
+        prompt: str,
+        *,
+        context: Optional[List[Dict[str, str]]] = None,
+        metadata: Optional[Dict[str, object]] = None,
     ) -> AsyncIterator[Dict]:
         """Yield progress updates for the thinking loop."""
         start_time = time.time()
+        metadata = metadata or {}
+        request_id = metadata.get("request_id") or generate_request_id()
+        metadata["request_id"] = request_id
+        logger.info("loop_start", request_id=request_id, prompt=prompt)
         initial = await self.engine._generate_initial(prompt, context)
         quality = await self.evaluate_step(prompt, initial.content)
         yield {

--- a/core/recursive_engine_v2.py
+++ b/core/recursive_engine_v2.py
@@ -126,11 +126,13 @@ class OptimizedRecursiveEngine:
         enable_streaming: bool = False,
     ) -> Dict:
         """Delegate to :class:`LoopController` for the main loop."""
+        metadata = {"request_id": generate_request_id()}
         return await self.loop_controller.run_loop(
             prompt,
             context=context,
             max_thinking_time=max_thinking_time,
             target_quality=target_quality,
+            metadata=metadata,
         )
 
     @trace_method("think_stream")
@@ -141,7 +143,10 @@ class OptimizedRecursiveEngine:
         context: Optional[List[Dict[str, str]]] = None,
     ):
         """Stream progress using :class:`LoopController`."""
-        async for update in self.loop_controller.run_stream(prompt, context=context):
+        metadata = {"request_id": generate_request_id()}
+        async for update in self.loop_controller.run_stream(
+            prompt, context=context, metadata=metadata
+        ):
             yield update
 
     @trace_method("generate_initial")


### PR DESCRIPTION
## Summary
- configure structlog JSON output with module metadata
- propagate generated `request_id` to `LoopController`
- note logging setup in README

## Testing
- `flake8 monitoring/telemetry.py core/chat_v2.py core/recursive_engine_v2.py core/loop_controller.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_684c8fcf782c8333a5d4f234c5df55cc