### PR TITLE
Expose Prometheus metrics

### DIFF
--- a/monitoring/telemetry.py
+++ b/monitoring/telemetry.py
@@ -441,15 +441,15 @@ def record_thinking_metrics(
         metrics.token_efficiency.record(total_tokens / rounds)
 
 
-def record_cache_metrics(hit: bool, cache_type: str = "memory") -> None:
+def record_cache_metrics(hit: bool, cache_type: str = "memory", *, count: int = 1) -> None:
     """Record cache hit/miss metrics."""
     metrics = get_metrics()
     labels = {"cache_type": cache_type}
-    
+
     if hit:
-        metrics.cache_hits.add(1, labels)
+        metrics.cache_hits.add(count, labels)
     else:
-        metrics.cache_misses.add(1, labels)
+        metrics.cache_misses.add(count, labels)
 
 
 def record_error(error_type: str, error_message: str) -> None:

--- a/recthink_web_v2.py
+++ b/recthink_web_v2.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, List
 
 import structlog
 
-from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -20,6 +20,7 @@ from core.loop_controller import LoopController
 from core.optimization.parallel_thinking import BatchThinkingOptimizer
 from monitoring.metrics_v2 import MetricsAnalyzer, ThinkingMetrics
 from monitoring.telemetry import initialize_telemetry, instrument_fastapi
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 from config.config import load_production_config
 
 app = FastAPI(title="RecThink API v2")
@@ -184,6 +185,12 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
         pass
     finally:
         await websocket.close()
+
+
+@app.get("/metrics")
+async def prometheus_metrics() -> Response:
+    """Expose Prometheus metrics."""
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 
 @app.get("/health/providers")


### PR DESCRIPTION
## Summary
- capture cache statistics in `CacheManager`
- pipe `ThinkingMetrics` into `CoRTMetrics`
- expose Prometheus endpoint on the API server
- allow `record_cache_metrics` to accept counts
- test Prometheus metrics endpoint

## Testing
- `flake8 monitoring/telemetry.py monitoring/metrics_v2.py core/cache_manager.py recthink_web_v2.py tests/test_monitoring.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_684c8fcfd4e883339f21888a4232f4d3